### PR TITLE
Disable dependency analyzing

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -9,7 +9,9 @@ val gitOpsRepo = "https://github.com/elhub/auth"
 elhubProject(group = Group.AUTH, name = "auth-consent-manager") {
     pipeline {
         sequential {
-            gradleVerify()
+            gradleVerify {
+                analyzeDependencies = false
+            }
 
             gradleJib {
                 registrySettings = {


### PR DESCRIPTION
Disabling owasp dependency check as latest version is struggling in TeamCity.
Doing this in order to get som progression on spinning up the application in Kubernetes. But we should put some traction on getting the owasp check fixed

