### PR TITLE
Remove id to some json schemas due to failing tests

### DIFF
--- a/src/main/resources/schemas/authorization-request-response.schema.json
+++ b/src/main/resources/schemas/authorization-request-response.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://api.elhub.no/schemas/authorization-request-read.schema.json",
   "title": "Authorization Request",
   "description": "Schema for returning a single authorization request in the Elhub authorization manager.",
   "type": "object",

--- a/src/main/resources/schemas/authorization-requests-get-response.schema.json
+++ b/src/main/resources/schemas/authorization-requests-get-response.schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://api.elhub.no/schemas/authorization-request-list.schema.json",
   "title": "Authorization Request Response Collection",
   "description": "Schema for returning a collection of authorization requests in the Elhub authorization manager.",
   "type": "object",


### PR DESCRIPTION
This PR, https://github.com/elhub/auth-grant-manager/pull/71, added an id property to some json schemas which made some tests in `AuthorizationRequestSchemaValidationTest` to fail. These tests shouldn't fail due to this. 

Removing them for now to proceed on the LiquiBase task
