### PR TITLE
Introduce the Devxp JSON:API wrapper and refactor models to use it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     implementation(libs.bundles.monitoring)
     // JSON validation
     implementation(libs.json.skema)
+
+    implementation(libs.elhub.json.wrapper)
     // Unit Testing
     testImplementation(libs.database.postgresql)
     testImplementation(libs.test.mockk)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ slf4j = "2.0.17"
 snakeyaml = "2.4"
 testcontainers = "1.20.6"
 mybatis = "3.5.19"
+jsonapi = "0.1.6"
 
 [plugins]
 elhub-gradle-plugin = { id = "no.elhub.devxp.kotlin-service", version.ref = "elhub-gradle" }
@@ -39,6 +40,7 @@ kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization"
 liquibase-plugin = { id = "org.liquibase.gradle", version.ref = "liquibase-plugin" }
 
 [libraries]
+elhub-json-wrapper = {group="no.elhub.devxp", name="devxp-json-api-wrapper",  version.ref = "jsonapi" }
 cli-picocli = { group = "info.picocli", name = "picocli", version.ref = "picocli" }
 database-exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 database-exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }

--- a/src/main/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentHandler.kt
@@ -16,10 +16,10 @@ class AuthorizationDocumentHandler {
         call.respond(status = HttpStatusCode.OK, message = ResponseMeta())
     }
 
-    fun postDocument(authorizationDocumentRequest: PostAuthorizationDocument.Request): AuthorizationDocument {
+    fun postDocument(authorizationDocumentRequest: PostAuthorizationDocumentRequest): AuthorizationDocument {
         val pdfBytes = PdfGenerator.createChangeOfSupplierConfirmationPdf(
-            authorizationDocumentRequest.data.relationships.requestedTo.data.id,
-            authorizationDocumentRequest.data.relationships.requestedBy.data.id
+            snn = authorizationDocumentRequest.data.relationships.requestedTo.data.id,
+            supplier = authorizationDocumentRequest.data.relationships.requestedBy.data.id
         )
         val authorizationDocument = AuthorizationDocument.of(authorizationDocumentRequest, pdfBytes)
         AuthorizationDocumentRepository.insertDocument(authorizationDocument)

--- a/src/main/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRoute.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRoute.kt
@@ -11,41 +11,16 @@ import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.elhub.auth.config.ID
-import no.elhub.auth.model.RelationshipLink
 import java.util.*
 
 fun Route.documentRoutes(documentService: AuthorizationDocumentHandler) {
     post {
-        val requestBody = call.receive<PostAuthorizationDocument.Request>()
+        val requestBody = call.receive<PostAuthorizationDocumentRequest>()
         val authorizationDocument = documentService.postDocument(requestBody)
 
-        val response = PostAuthorizationDocument.Response(
-            data = PostAuthorizationDocument.Response.Data(
-                id = authorizationDocument.id.toString(),
-                type = "AuthorizationDocument",
-                attributes = PostAuthorizationDocument.Response.Data.Attributes(
-                    createdAt = authorizationDocument.createdAt.toString(),
-                    updatedAt = authorizationDocument.updatedAt.toString(),
-                    status = authorizationDocument.status.toString()
-                ),
-                relationships = PostAuthorizationDocument.Response.Data.Relationships(
-                    requestedBy = RelationshipLink(
-                        data = RelationshipLink.DataLink(
-                            id = authorizationDocument.requestedBy,
-                            type = "User"
-                        )
-                    ),
-                    requestedTo = RelationshipLink(
-                        data = RelationshipLink.DataLink(
-                            id = authorizationDocument.requestedTo,
-                            type = "User"
-                        )
-                    ),
-                )
+        val responseBody = authorizationDocument.toPostAuthorizationDocumentResponse()
 
-            ),
-        )
-        call.respond(status = HttpStatusCode.Created, message = response)
+        call.respond(status = HttpStatusCode.Created, message = responseBody)
     }
 
     route("/{$ID}") {

--- a/src/main/kotlin/no/elhub/auth/features/documents/PostAuthorizationDocument.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/PostAuthorizationDocument.kt
@@ -1,56 +1,64 @@
 package no.elhub.auth.features.documents
 
 import kotlinx.serialization.Serializable
-import no.elhub.auth.model.RelationshipLink
+import no.elhub.auth.model.AuthorizationDocument
+import no.elhub.devxp.jsonapi.model.JsonApiAttributes
+import no.elhub.devxp.jsonapi.model.JsonApiRelationshipData
+import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToOne
+import no.elhub.devxp.jsonapi.model.JsonApiRelationships
+import no.elhub.devxp.jsonapi.request.JsonApiRequest
+import no.elhub.devxp.jsonapi.response.JsonApiResponse
+import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationships
 
-class PostAuthorizationDocument {
-    @Serializable
-    data class Request(
-        val data: Data
-    ) {
-        @Serializable
-        data class Data(
-            val type: String,
-            val attributes: Attributes,
-            val relationships: Relationships,
+@Serializable
+data class DocumentRequestAttributes(
+    val meteringPoint: String
+) : JsonApiAttributes
 
-        ) {
-            @Serializable
-            data class Attributes(
-                val meteringPoint: String,
+@Serializable
+data class DocumentResponseAttributes(
+    val status: String,
+    val createdAt: String,
+    val updatedAt: String
+) : JsonApiAttributes
+
+@Serializable
+data class DocumentRelationships(
+    val requestedBy: JsonApiRelationshipToOne,
+    val requestedTo: JsonApiRelationshipToOne
+) : JsonApiRelationships
+
+typealias PostAuthorizationDocumentRequest = JsonApiRequest.SingleDocumentWithRelationships<DocumentRequestAttributes, DocumentRelationships>
+typealias PostAuthorizationDocumentResponse = JsonApiResponse.SingleDocumentWithRelationships<DocumentResponseAttributes, DocumentRelationships>
+
+fun AuthorizationDocument.toPostAuthorizationDocumentResponse(): PostAuthorizationDocumentResponse {
+    val attributes = DocumentResponseAttributes(
+        status = this.status.toString(),
+        createdAt = this.createdAt.toString(),
+        updatedAt = this.updatedAt.toString()
+    )
+
+    val relationships = DocumentRelationships(
+        requestedBy = JsonApiRelationshipToOne(
+            data = JsonApiRelationshipData(
+                id = this.requestedBy,
+                type = "User"
             )
-
-            @Serializable
-            data class Relationships(
-                val requestedBy: RelationshipLink,
-                val requestedTo: RelationshipLink,
+        ),
+        requestedTo = JsonApiRelationshipToOne(
+            data = JsonApiRelationshipData(
+                id = this.requestedTo,
+                type = "User"
             )
-        }
-    }
+        )
+    )
 
-    @Serializable
-    data class Response(
-        val data: Data
-    ) {
-        @Serializable
-        data class Data(
-            val type: String,
-            val id: String,
-            val attributes: Attributes,
-            val relationships: Relationships
-        ) {
-            @Serializable
-            data class Attributes(
-                val status: String,
-                val createdAt: String,
-                val updatedAt: String
-            )
-
-            @Serializable
-            data class Relationships(
-                val requestedBy: RelationshipLink,
-                val requestedTo: RelationshipLink,
-            )
-        }
-    }
+    return PostAuthorizationDocumentResponse(
+        data = JsonApiResponseResourceObjectWithRelationships(
+            type = "AuthorizationDocument",
+            id = this.id.toString(),
+            attributes = attributes,
+            relationships = relationships
+        )
+    )
 }

--- a/src/main/kotlin/no/elhub/auth/model/AuthorizationDocument.kt
+++ b/src/main/kotlin/no/elhub/auth/model/AuthorizationDocument.kt
@@ -1,6 +1,6 @@
 package no.elhub.auth.model
 
-import no.elhub.auth.features.documents.PostAuthorizationDocument
+import no.elhub.auth.features.documents.PostAuthorizationDocumentRequest
 import no.elhub.auth.utils.PGEnum
 import org.jetbrains.exposed.dao.id.UUIDTable
 import org.jetbrains.exposed.sql.javatime.datetime
@@ -20,7 +20,7 @@ data class AuthorizationDocument(
 ) {
 
     companion object {
-        fun of(postAuthorizationDocumentRequest: PostAuthorizationDocument.Request, pdf: ByteArray): AuthorizationDocument = AuthorizationDocument(
+        fun of(postAuthorizationDocumentRequest: PostAuthorizationDocumentRequest, pdf: ByteArray): AuthorizationDocument = AuthorizationDocument(
             id = UUID.randomUUID(),
             title = "Title",
             pdfBytes = pdf,

--- a/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRepositoryTest.kt
@@ -6,7 +6,9 @@ import no.elhub.auth.extensions.PostgresTestContainerExtension
 import no.elhub.auth.model.AuthorizationDocument
 import no.elhub.auth.model.AuthorizationDocumentScopes
 import no.elhub.auth.model.AuthorizationScopes
-import no.elhub.auth.model.RelationshipLink
+import no.elhub.devxp.jsonapi.model.JsonApiRelationshipData
+import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToOne
+import no.elhub.devxp.jsonapi.request.JsonApiRequestResourceObjectWithRelationships
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -30,20 +32,19 @@ class AuthorizationDocumentRepositoryTest :
                 // Given
                 val document =
                     AuthorizationDocument.of(
-                        PostAuthorizationDocument.Request(
-                            data =
-                                PostAuthorizationDocument.Request.Data(
-                                    type = "authorization_document",
-                                    attributes =
-                                        PostAuthorizationDocument.Request.Data.Attributes(
-                                            meteringPoint = "1234",
-                                        ),
-                                    relationships =
-                                        PostAuthorizationDocument.Request.Data.Relationships(
-                                            requestedBy = RelationshipLink(RelationshipLink.DataLink("12345678901", "User")),
-                                            requestedTo = RelationshipLink(RelationshipLink.DataLink("98765432109", "User")),
-                                        ),
-                                ),
+                        PostAuthorizationDocumentRequest(
+                            data = JsonApiRequestResourceObjectWithRelationships(
+                                type = "authorization_document",
+                                attributes = DocumentRequestAttributes(meteringPoint = "1234"),
+                                relationships = DocumentRelationships(
+                                    requestedBy = JsonApiRelationshipToOne(
+                                        data = JsonApiRelationshipData(type = "User", id = "12345678901")
+                                    ),
+                                    requestedTo = JsonApiRelationshipToOne(
+                                        data = JsonApiRelationshipData(type = "User", id = "12345678901")
+                                    )
+                                )
+                            )
                         ),
                         byteArrayOf(),
                     )


### PR DESCRIPTION
Currently not very happy about that we have to reference
JsonApiResponseResourceObjectWithRelationships when mapping to the
JSON:API response, but will look into this later
