### PR TITLE
Read vault token from file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,7 +121,7 @@ val localEnvVars = mapOf(
     "APP_PASSWORD" to "app",
     "VAULT_URL" to "http://localhost:8200",
     "VAULT_KEY" to "test-key",
-    "VAULT_TOKEN" to "test-key",
+    "VAULT_TOKEN_PATH" to "somepath",
     "PATH_TO_SIGNING_CERTIFICATE" to testCertPath.get(),
     "PATH_TO_SIGNING_CERTIFICATE_CHAIN" to testCertPath.get(),
 )

--- a/src/main/kotlin/no/elhub/auth/config/Koin.kt
+++ b/src/main/kotlin/no/elhub/auth/config/Koin.kt
@@ -22,7 +22,7 @@ import java.security.cert.X509Certificate
 data class VaultConfig(
     val url: String,
     val key: String,
-    val token: String
+    val tokenPath: String
 )
 
 data class CertificateConfig(
@@ -38,7 +38,7 @@ val signerModule = module {
         VaultConfig(
             url = cfg.property("url").getString(),
             key = cfg.property("key").getString(),
-            token = cfg.property("token").getString(),
+            tokenPath = cfg.property("tokenPath").getString(),
         )
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -17,7 +17,7 @@ pdfSigner:
   vault:
     url: ${VAULT_URL}
     key: ${VAULT_KEY}
-    token: ${VAULT_TOKEN}
+    tokenPath: ${VAULT_TOKEN_PATH}
   certificate:
     signing: ${PATH_TO_SIGNING_CERTIFICATE}
     chain: ${PATH_TO_SIGNING_CERTIFICATE_CHAIN}

--- a/src/test/kotlin/no/elhub/auth/extensions/VaultTransitExtension.kt
+++ b/src/test/kotlin/no/elhub/auth/extensions/VaultTransitExtension.kt
@@ -74,4 +74,4 @@ object StopVaultTransitTestContainer : AfterProjectListener {
     }
 }
 
-val localVaultConfig = VaultConfig(url = "http://localhost:$VAULT_PORT", key = "test-key", tokenPath = "something")
+val localVaultConfig = VaultConfig(url = "http://localhost:$VAULT_PORT", key = "test-key", tokenPath = "src/test/resources/vault_token_mock.txt")

--- a/src/test/kotlin/no/elhub/auth/extensions/VaultTransitExtension.kt
+++ b/src/test/kotlin/no/elhub/auth/extensions/VaultTransitExtension.kt
@@ -74,4 +74,4 @@ object StopVaultTransitTestContainer : AfterProjectListener {
     }
 }
 
-val localVaultConfig = VaultConfig(url = "http://localhost:$VAULT_PORT", key = "test-key", token = "something")
+val localVaultConfig = VaultConfig(url = "http://localhost:$VAULT_PORT", key = "test-key", tokenPath = "something")

--- a/src/test/kotlin/no/elhub/auth/utils/TestApplication.kt
+++ b/src/test/kotlin/no/elhub/auth/utils/TestApplication.kt
@@ -15,7 +15,7 @@ fun defaultTestApplication(): TestApplication = TestApplication {
             "ktor.database.url" to "jdbc:postgresql://localhost:5432/auth",
             "ktor.database.driverClass" to "org.postgresql.Driver",
             "pdfSigner.vault.url" to "http://localhost:8200",
-            "pdfSigner.vault.token" to "something",
+            "pdfSigner.vault.tokenPath" to "src/test/resources/vault_token_mock.txt",
             "pdfSigner.vault.key" to "test-key",
             "pdfSigner.certificate.signing" to TestCertificateUtil.Constants.CERTIFICATE_LOCATION,
             "pdfSigner.certificate.chain" to TestCertificateUtil.Constants.CERTIFICATE_LOCATION,

--- a/src/test/resources/vault_token_mock.txt
+++ b/src/test/resources/vault_token_mock.txt
@@ -1,0 +1,1 @@
+bla.CAESIAIUe6sIblauvUD_bla-8tBaUysB8pv--HGh4KHGh2cy4wMmFblahZ3Z0NkVrNzRxSHh2Mm1HUkxCTkk


### PR DESCRIPTION
Vault token creation and renewal will be handled in Kubernetes by Vault Agent Injector which mounts a file to the running container so that the container can read the token.
We therefore have to change setup so that the application accepts a file location instead of the actual token
