### PR TITLE
Make validTo field be provided by value streams and not in request body [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/requests/create/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/Route.kt
@@ -34,8 +34,8 @@ fun Route.route(handler: Handler) {
                     CreateRequestError.RequestedFromPartyError,
                     -> call.respond(HttpStatusCode.InternalServerError)
                     is CreateRequestError.ValidationError -> {
-                        val (status, error) = error.toApiErrorResponse()
-                        call.respond(status, error)
+                        val (status, validationError) = error.toApiErrorResponse()
+                        call.respond(status, validationError)
                     }
                 }
                 return@post

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/dto/JsonApiCreateRequest.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/dto/JsonApiCreateRequest.kt
@@ -1,6 +1,5 @@
 package no.elhub.auth.features.requests.create.dto
 
-import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
 import no.elhub.auth.features.common.PartyIdentifier
 import no.elhub.auth.features.requests.AuthorizationRequest
@@ -11,7 +10,6 @@ import no.elhub.devxp.jsonapi.request.JsonApiRequest
 
 @Serializable
 data class CreateRequestAttributes(
-    val validTo: LocalDate,
     val requestType: AuthorizationRequest.Type,
 ) : JsonApiAttributes
 
@@ -32,8 +30,7 @@ typealias JsonApiCreateRequest = JsonApiRequest.SingleDocumentWithMeta<CreateReq
 fun JsonApiCreateRequest.toModel(): CreateRequestModel =
     CreateRequestModel(
         requestType = this.data.attributes.requestType,
-        validTo = this.data.attributes.validTo,
-        meta = this.data.meta.toModel(),
+        meta = this.data.meta.toModel()
     )
 
 fun CreateRequestMeta.toModel(): no.elhub.auth.features.requests.create.model.CreateRequestMeta =

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/model/CreateRequestModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/model/CreateRequestModel.kt
@@ -1,11 +1,9 @@
 package no.elhub.auth.features.requests.create.model
 
-import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.common.PartyIdentifier
 import no.elhub.auth.features.requests.AuthorizationRequest
 
 data class CreateRequestModel(
-    val validTo: LocalDate,
     val requestType: AuthorizationRequest.Type,
     val meta: CreateRequestMeta,
 )

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/requesttypes/changeofsupplierconfirmation/ChangeOfSupplierConfirmationRequestTypeHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/requesttypes/changeofsupplierconfirmation/ChangeOfSupplierConfirmationRequestTypeHandler.kt
@@ -3,12 +3,19 @@ package no.elhub.auth.features.requests.create.requesttypes.changeofsupplierconf
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.create.command.RequestCommand
 import no.elhub.auth.features.requests.create.command.RequestMetaMarker
 import no.elhub.auth.features.requests.create.model.CreateRequestModel
 import no.elhub.auth.features.requests.create.requesttypes.RequestTypeHandler
 import no.elhub.auth.features.requests.create.requesttypes.RequestTypeValidationError
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 private const val REGEX_NUMBERS_LETTERS_SYMBOLS = "^[a-zA-Z0-9_.-]*$"
 private const val REGEX_REQUESTED_FROM = REGEX_NUMBERS_LETTERS_SYMBOLS
@@ -70,12 +77,22 @@ class ChangeOfSupplierConfirmationRequestTypeHandler : RequestTypeHandler {
                 requestedBy = meta.requestedBy,
                 requestedFrom = meta.requestedFrom,
                 requestedTo = meta.requestedTo,
-                validTo = model.validTo,
+                validTo = calculateValidTo(),
                 meta = changeOfSupplierMeta,
             )
 
         return command.right()
     }
+}
+
+/**
+ * Calculate the validity for an authorization request
+ * Currently temporary - should be replaced with the actual validation/calculation by the value stream
+ */
+@OptIn(ExperimentalTime::class)
+private fun calculateValidTo(): LocalDate {
+    val now = Clock.System.now().toLocalDateTime(TimeZone.UTC).date
+    return now.plus(DatePeriod(days = 30))
 }
 
 private data class ChangeOfSupplierRequestMeta(

--- a/src/main/resources/static/schemas/requests/authorization-request-post-request.schema.json
+++ b/src/main/resources/static/schemas/requests/authorization-request-post-request.schema.json
@@ -17,9 +17,6 @@
           "properties": {
             "requestType": {
               "$ref": "authorization-request-definitions.json#/$defs/attributes/$defs/requestType"
-            },
-            "status": {
-              "$ref": "authorization-request-definitions.json#/$defs/attributes/$defs/status"
             }
           }
         },

--- a/src/test/kotlin/no/elhub/auth/features/requests/AuthorizationRequestRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/AuthorizationRequestRouteTest.kt
@@ -14,7 +14,6 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.testing.testApplication
-import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.common.AuthPersonsTestContainer
 import no.elhub.auth.features.common.AuthPersonsTestContainerExtension
 import no.elhub.auth.features.common.PartyIdentifier
@@ -272,7 +271,6 @@ class AuthorizationRequestRouteTest :
                                             type = "AuthorizationRequest",
                                             attributes =
                                             CreateRequestAttributes(
-                                                validTo = kotlinx.datetime.LocalDate.parse("2030-01-01"),
                                                 requestType = AuthorizationRequest.Type.ChangeOfSupplierConfirmation,
                                             ),
                                             meta =
@@ -305,7 +303,6 @@ class AuthorizationRequestRouteTest :
                                             type = "AuthorizationRequest",
                                             attributes =
                                             CreateRequestAttributes(
-                                                validTo = LocalDate.parse("2030-01-01"),
                                                 requestType = AuthorizationRequest.Type.ChangeOfSupplierConfirmation,
                                             ),
                                             meta =

--- a/src/test/kotlin/no/elhub/auth/features/requests/create/requesttypes/changeofsupplierconfirmation/ChangeOfSupplierConfirmationRequestTypeHandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/create/requesttypes/changeofsupplierconfirmation/ChangeOfSupplierConfirmationRequestTypeHandlerTest.kt
@@ -3,8 +3,8 @@ package no.elhub.auth.features.requests.create.requesttypes.changeofsupplierconf
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.common.PartyIdentifier
 import no.elhub.auth.features.common.PartyIdentifierType
 import no.elhub.auth.features.requests.AuthorizationRequest
@@ -20,7 +20,6 @@ class ChangeOfSupplierConfirmationRequestTypeHandlerTest :
             val handler = ChangeOfSupplierConfirmationRequestTypeHandler()
             val model =
                 CreateRequestModel(
-                    validTo = LocalDate.parse("2030-01-01"),
                     requestType = AuthorizationRequest.Type.ChangeOfSupplierConfirmation,
                     meta =
                     CreateRequestMeta(
@@ -44,7 +43,6 @@ class ChangeOfSupplierConfirmationRequestTypeHandlerTest :
             val handler = ChangeOfSupplierConfirmationRequestTypeHandler()
             val model =
                 CreateRequestModel(
-                    validTo = LocalDate.parse("2030-01-01"),
                     requestType = AuthorizationRequest.Type.ChangeOfSupplierConfirmation,
                     meta =
                     CreateRequestMeta(
@@ -65,6 +63,7 @@ class ChangeOfSupplierConfirmationRequestTypeHandlerTest :
             command.requestedBy shouldBe model.meta.requestedBy
             command.requestedFrom shouldBe model.meta.requestedFrom
             command.requestedTo shouldBe model.meta.requestedTo
+            command.validTo.shouldNotBeNull()
 
             val metaAttributes = command.meta.toMetaAttributes()
             metaAttributes["requestedFromName"] shouldBe "Supplier AS"


### PR DESCRIPTION
## 📝 Description

Also update openapi spec for auth-req POST to not have status in the request body

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
