### PR TITLE
Add openApi tags to group endpoints in SwaggerUI [patch]

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -47,6 +47,8 @@ paths:
           $ref: "#/components/responses/401UnauthorizedError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationDocuments
     post:
       summary: Initiate a new authorization document flow.
       description: Initiate a new authorization document flow. This creates a authorization document for signing.
@@ -88,6 +90,8 @@ paths:
           $ref: "#/components/responses/401UnauthorizedError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationDocuments
   "/authorization-documents/{id}":
     get:
       summary: Retrieve information about a specific authorization document.
@@ -132,6 +136,8 @@ paths:
           $ref: "#/components/responses/404NotFoundError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationDocuments
     delete:
       summary: Delete/cancel a signed document.
       description: Cancel a document to be signed. This can only be done if the document is not yet signed.
@@ -217,6 +223,8 @@ paths:
           $ref: "#/components/responses/404NotFoundError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationDocuments
     put:
       summary: Submit a signed authorization document.
       description: Submit a signed authorization document. Elhub will validate the document, generate any necessary authorization grants and store the document.
@@ -262,6 +270,8 @@ paths:
           $ref: "#/components/responses/401UnauthorizedError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationDocuments
   "/authorization-grants":
     get:
       summary: Retrieve a list of authorization grants.
@@ -298,6 +308,8 @@ paths:
           $ref: "#/components/responses/401UnauthorizedError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationGrants
   "/authorization-grants/{id}":
     get:
       summary: Retrieve a specific authorization grant.
@@ -342,6 +354,8 @@ paths:
           $ref: "#/components/responses/400BadRequestError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationGrants
     patch:
       summary: Update the status of an authorization grant
       description: Update the authorization grant status. This is an internal API for BRS.
@@ -419,6 +433,8 @@ paths:
           $ref: "#/components/responses/404NotFoundError"
         "500":
           $ref: "#/components/responses/500InternalServerError"
+      tags:
+        - AuthorizationGrants
   "/authorization-requests":
     get:
       summary: Retrieve a list of authorization requests.


### PR DESCRIPTION
## 📝 Description

Keep existing TODO tags for endpoints that are still under development and disabled

Ref: https://github.com/elhub/auth-grant-manager/issues/316

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
