### PR TITLE
Fix reference in openapi spec [patch]

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -55,7 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                ref: "./schemas/documents/authorization-document-collectionn.schema.json"
+                $ref: "./schemas/documents/authorization-document-collection.schema.json"
         "401":
           $ref: "#/components/responses/401UnauthorizedError"
         "500":


### PR DESCRIPTION
## 📝 Description

Schema reference in the openApi spec is missing `$` for GET `/authorization-documents`

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
