### PR TITLE
Correct resourceId in examples [patch]

### DIFF
--- a/src/main/resources/static/schemas/base-definitions.schema.json
+++ b/src/main/resources/static/schemas/base-definitions.schema.json
@@ -26,7 +26,7 @@
           "examples": [
             {
               "type": "Person",
-              "resourceId": "12345678901"
+              "resourceId": "56365eae-bc09-5c51-e063-9f768d0ac8cf"
             }
           ]
         }


### PR DESCRIPTION
## 📝 Description

The `resourceId` should be `elhubInternalId` when the type is `Person`

## 🔗 Issue ID(s): [TDX-1250](https://elhub.atlassian.net/browse/TDX-1250)

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.


[TDX-1250]: https://elhub.atlassian.net/browse/TDX-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ