### PR TITLE
refactor: add Request/DocumentBusinessHandler test implementations to reduce auth/value-stream coupling

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/BusinessProcessesModule.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/BusinessProcessesModule.kt
@@ -1,0 +1,21 @@
+package no.elhub.auth.features.businessprocesses
+
+import io.ktor.server.application.Application
+import no.elhub.auth.features.businessprocesses.changeofsupplier.ChangeOfSupplierBusinessHandler
+import no.elhub.auth.features.businessprocesses.movein.MoveInBusinessHandler
+import no.elhub.auth.features.documents.common.DocumentBusinessHandler
+import no.elhub.auth.features.documents.common.ProxyDocumentBusinessHandler
+import no.elhub.auth.features.requests.common.ProxyRequestBusinessHandler
+import no.elhub.auth.features.requests.create.RequestBusinessHandler
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
+import org.koin.ktor.plugin.koinModule
+
+fun Application.businessProcessesModule() {
+    koinModule {
+        singleOf(::ChangeOfSupplierBusinessHandler)
+        singleOf(::MoveInBusinessHandler)
+        singleOf(::ProxyDocumentBusinessHandler) bind DocumentBusinessHandler::class
+        singleOf(::ProxyRequestBusinessHandler) bind RequestBusinessHandler::class
+    }
+}

--- a/src/main/kotlin/no/elhub/auth/features/documents/Module.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/Module.kt
@@ -6,14 +6,11 @@ import io.ktor.server.application.Application
 import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
-import no.elhub.auth.features.businessprocesses.changeofsupplier.ChangeOfSupplierBusinessHandler
-import no.elhub.auth.features.businessprocesses.movein.MoveInBusinessHandler
 import no.elhub.auth.features.documents.common.DocumentPropertiesRepository
 import no.elhub.auth.features.documents.common.DocumentRepository
 import no.elhub.auth.features.documents.common.ExposedDocumentPropertiesRepository
 import no.elhub.auth.features.documents.common.ExposedDocumentRepository
 import no.elhub.auth.features.documents.common.PdfSignatureService
-import no.elhub.auth.features.documents.common.ProxyDocumentBusinessHandler
 import no.elhub.auth.features.documents.common.SignatureService
 import no.elhub.auth.features.documents.create.CertificateProvider
 import no.elhub.auth.features.documents.create.FileCertificateProvider
@@ -78,9 +75,6 @@ fun Application.module() {
         singleOf(::ExposedDocumentRepository) bind DocumentRepository::class
         singleOf(::ExposedGrantRepository) bind GrantRepository::class
         singleOf(::ExposedDocumentPropertiesRepository) bind DocumentPropertiesRepository::class
-        singleOf(::ChangeOfSupplierBusinessHandler)
-        singleOf(::MoveInBusinessHandler)
-        singleOf(::ProxyDocumentBusinessHandler)
         singleOf(::ConfirmHandler)
         singleOf(::CreateHandler)
         singleOf(::GetHandler)

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentBusinessHandler.kt
@@ -5,17 +5,13 @@ import no.elhub.auth.features.businessprocesses.changeofsupplier.ChangeOfSupplie
 import no.elhub.auth.features.businessprocesses.movein.MoveInBusinessHandler
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.create.CreateError
-import no.elhub.auth.features.documents.create.DocumentGenerationError
-import no.elhub.auth.features.documents.create.FileGenerator
 import no.elhub.auth.features.documents.create.command.DocumentCommand
-import no.elhub.auth.features.documents.create.command.DocumentMetaMarker
 import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 
 class ProxyDocumentBusinessHandler(
     private val changeOfSupplierHandler: ChangeOfSupplierBusinessHandler,
     private val moveInHandler: MoveInBusinessHandler,
-    private val fileGenerator: FileGenerator,
 ) : DocumentBusinessHandler {
     override fun validateAndReturnDocumentCommand(model: CreateDocumentModel): Either<CreateError.BusinessValidationError, DocumentCommand> =
         when (model.documentType) {
@@ -28,11 +24,6 @@ class ProxyDocumentBusinessHandler(
             AuthorizationDocument.Type.ChangeOfSupplierConfirmation -> changeOfSupplierHandler.getCreateGrantProperties(document)
             AuthorizationDocument.Type.MoveIn -> moveInHandler.getCreateGrantProperties(document)
         }
-
-    fun generateFile(
-        signatoryId: String,
-        documentMeta: DocumentMetaMarker,
-    ): Either<DocumentGenerationError.ContentGenerationError, ByteArray> = fileGenerator.generate(signatoryId, documentMeta)
 }
 
 interface DocumentBusinessHandler {

--- a/src/main/kotlin/no/elhub/auth/features/requests/Module.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/Module.kt
@@ -3,8 +3,6 @@ package no.elhub.auth.features.requests
 import io.ktor.server.application.Application
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
-import no.elhub.auth.features.businessprocesses.changeofsupplier.ChangeOfSupplierBusinessHandler
-import no.elhub.auth.features.businessprocesses.movein.MoveInBusinessHandler
 import no.elhub.auth.features.grants.common.ExposedGrantRepository
 import no.elhub.auth.features.grants.common.GrantRepository
 import no.elhub.auth.features.requests.common.ExposedRequestPropertiesRepository
@@ -33,8 +31,6 @@ fun Application.module() {
         singleOf(::ExposedRequestRepository) bind RequestRepository::class
         singleOf(::ExposedGrantRepository) bind GrantRepository::class
         singleOf(::ExposedRequestPropertiesRepository) bind RequestPropertiesRepository::class
-        singleOf(::ChangeOfSupplierBusinessHandler)
-        singleOf(::MoveInBusinessHandler)
         singleOf(::ProxyRequestBusinessHandler)
         singleOf(::UpdateHandler)
         singleOf(::CreateHandler)

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/Handler.kt
@@ -7,7 +7,6 @@ import no.elhub.auth.features.common.party.PartyService
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AuthorizationRequestProperty
-import no.elhub.auth.features.requests.common.ProxyRequestBusinessHandler
 import no.elhub.auth.features.requests.common.RequestPropertiesRepository
 import no.elhub.auth.features.requests.common.RequestRepository
 import no.elhub.auth.features.requests.create.command.RequestCommand
@@ -16,7 +15,7 @@ import no.elhub.auth.features.requests.create.requesttypes.RequestTypeValidation
 import org.jetbrains.exposed.sql.transactions.transaction
 
 class Handler(
-    private val proxyRequestBusinessHandler: ProxyRequestBusinessHandler,
+    private val businessHandler: RequestBusinessHandler,
     private val partyService: PartyService,
     private val requestRepo: RequestRepository,
     private val requestPropertyRepo: RequestPropertiesRepository,
@@ -45,7 +44,7 @@ class Handler(
                 .bind()
 
         val businessCommand =
-            proxyRequestBusinessHandler
+            businessHandler
                 .validateAndReturnRequestCommand(model)
                 .mapLeft { validationError -> CreateError.ValidationError(validationError) }
                 .bind()

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,7 @@ ktor:
     modules:
       - no.elhub.auth.ApplicationKt.module
       - no.elhub.auth.features.common.CommonModuleKt.commonModule
+      - no.elhub.auth.features.businessprocesses.BusinessProcessesModuleKt.businessProcessesModule
       - no.elhub.auth.features.openapi.ModuleKt.module
       - no.elhub.auth.features.grants.ModuleKt.module
       - no.elhub.auth.features.documents.ModuleKt.module
@@ -36,12 +37,12 @@ pdp:
   baseUrl: ${PDP_BASE_URL}
 
 authPersons:
-  baseUri: $AUTH_PERSONS_URL
+  baseUri: https://auth-persons-test9.elhub.cloud
 
 structureData:
   meteringPointsService:
-    serviceUrl: $STRUCTURE_DATA_METERING_POINTS_SERVICE_URL
+    serviceUrl: something
     authentication:
       basic:
-        username: $STRUCTURE_DATA_METERING_POINTS_SERVICE_API_USERNAME
-        password: $STRUCTURE_DATA_METERING_POINTS_SERVICE_API_PASSWORD
+        username: something
+        password: something


### PR DESCRIPTION
- centralize Koin singleton wiring for handlers to make ownership clearer
- use test impls in auth tests so value streams don't need to update them
- remove hard coupling between auth and value-stream handler behavior
