### PR TITLE
Register MeteringPointsService module before BusinessProcess [patch]

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,12 +3,12 @@ ktor:
     modules:
       - no.elhub.auth.ApplicationKt.module
       - no.elhub.auth.features.common.CommonModuleKt.commonModule
+      - no.elhub.auth.features.businessprocesses.structuredata.MeteringPointsServiceModuleKt.meteringPointsServiceModule
       - no.elhub.auth.features.businessprocesses.BusinessProcessesModuleKt.businessProcessesModule
       - no.elhub.auth.features.openapi.ModuleKt.module
       - no.elhub.auth.features.grants.ModuleKt.module
       - no.elhub.auth.features.documents.ModuleKt.module
       - no.elhub.auth.features.requests.ModuleKt.module
-      - no.elhub.auth.features.businessprocesses.structuredata.MeteringPointsServiceModuleKt.meteringPointsServiceModule
   deployment:
     port: 8080
   database:


### PR DESCRIPTION
## 📝 Description

The `BusinessProcessesModule` depends on `MeteringPointsService` at startup and Koin tried to resovle that dependency before the service binding existed.  Moving `MeteringPointsService` earlier to ensure binding is registered. Preventing `NoDefinitionFoundException`

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
