### PR TITLE
Remove JSON:API error code field until consumer semantics are defined

### DIFF
--- a/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
+++ b/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
@@ -29,7 +29,6 @@ fun Application.configureErrorHandling() {
                     logger.error("Unhandled exception", cause)
                     val (status, body) = buildApiErrorResponse(
                         status = HttpStatusCode.InternalServerError,
-                        code = "internal_error",
                         title = "Internal server error",
                         detail = "An unexpected error occurred"
                     )

--- a/src/main/kotlin/no/elhub/auth/config/RequestHeaderPolicy.kt
+++ b/src/main/kotlin/no/elhub/auth/config/RequestHeaderPolicy.kt
@@ -27,7 +27,6 @@ val HeaderPolicy = createApplicationPlugin(
 val MissingUserAgentHeder: JsonApiErrorObject =
     JsonApiErrorObject(
         status = "400",
-        code = "bad_request",
         title = "Bad request",
         detail = "Missing User-Agent header"
     )

--- a/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
@@ -35,12 +35,11 @@ sealed class RepositoryReadError : RepositoryError() {
     data object UnexpectedError : RepositoryReadError()
 }
 
-fun buildApiErrorResponse(status: HttpStatusCode, code: String, title: String, detail: String) =
+fun buildApiErrorResponse(status: HttpStatusCode, title: String, detail: String) =
     status to JsonApiErrorCollection(
         listOf(
             JsonApiErrorObject(
                 status = status.value.toString(),
-                code = code,
                 title = title,
                 detail = detail
             )
@@ -49,14 +48,12 @@ fun buildApiErrorResponse(status: HttpStatusCode, code: String, title: String, d
 
 fun toDeserializationApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection> = buildApiErrorResponse(
     status = HttpStatusCode.BadRequest,
-    code = "invalid_request_body",
     title = "Invalid request body",
     detail = "Request body could not be parsed or did not match the expected schema"
 )
 
 fun toBalanceSupplierNotApiAuthorizedResponse(): Pair<HttpStatusCode, JsonApiErrorCollection> = buildApiErrorResponse(
     status = HttpStatusCode.Forbidden,
-    code = "not_authorized",
     title = "Not authorized",
     detail = "Only balance suppliers are authorized to access this endpoint"
 )
@@ -65,14 +62,12 @@ fun InputError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection
     when (this) {
         InputError.MissingInputError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "missing_input",
             title = "Missing input",
             detail = "Necessary information was not provided",
         )
 
         InputError.MalformedInputError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "invalid_input",
             title = "Invalid input",
             detail = "The provided payload did not satisfy the expected format"
         )
@@ -82,21 +77,18 @@ fun QueryError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection
     when (this) {
         QueryError.ResourceNotFoundError -> buildApiErrorResponse(
             status = HttpStatusCode.NotFound,
-            code = "not_found",
             title = "Not found",
             detail = "The requested resource could not be found",
         )
 
         QueryError.IOError -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_error",
             title = "Internal server error",
             detail = "An error occurred when attempted to perform the query",
         )
 
         QueryError.NotAuthorizedError -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
-            code = "not_authorized",
             title = "Party not authorized",
             detail = "The party is not allowed to access this resource",
         )

--- a/src/main/kotlin/no/elhub/auth/features/common/auth/AuthErrorJsonApiResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/auth/AuthErrorJsonApiResponse.kt
@@ -8,35 +8,30 @@ fun AuthError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection>
     when (this) {
         AuthError.MissingAuthorizationHeader -> buildApiErrorResponse(
             status = HttpStatusCode.Unauthorized,
-            code = "missing_authorization",
             title = "Missing authorization",
             detail = "Bearer token is required in the Authorization header."
         )
 
         AuthError.InvalidAuthorizationHeader -> buildApiErrorResponse(
             status = HttpStatusCode.Unauthorized,
-            code = "invalid_authorization_header",
             title = "Invalid authorization header",
             detail = "Authorization header must use the Bearer scheme."
         )
 
         AuthError.MissingSenderGlnHeader -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "missing_sender_gln",
             title = "Missing senderGLN header",
             detail = "SenderGLN header is required for authorization."
         )
 
         AuthError.InvalidToken -> buildApiErrorResponse(
             status = HttpStatusCode.Unauthorized,
-            code = "invalid_token",
             title = "Invalid token",
             detail = "Token could not be verified."
         )
 
         AuthError.ActingFunctionNotSupported -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
-            code = "unsupported_party_type",
             title = "Unsupported party type",
             detail = "The party type you are authorized as is not supported for this endpoint."
         )
@@ -47,14 +42,12 @@ fun AuthError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection>
         AuthError.UnexpectedError,
         AuthError.UnknownError -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_server_error",
             title = "Internal server error",
             detail = "An internal error occurred."
         )
 
         AuthError.NotAuthorized -> buildApiErrorResponse(
             status = HttpStatusCode.Unauthorized,
-            code = "not_authorized",
             title = "Not authorized",
             detail = "Not authorized for this endpoint."
         )

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/ConfirmError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/ConfirmError.kt
@@ -24,7 +24,6 @@ fun ConfirmError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollecti
     when (this) {
         ConfirmError.DocumentNotFoundError -> buildApiErrorResponse(
             status = HttpStatusCode.NotFound,
-            code = "not_found",
             title = "Not found",
             detail = "Document could not be found"
         )
@@ -38,28 +37,24 @@ fun ConfirmError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollecti
         ConfirmError.GrantCreationError,
         ConfirmError.RequestedByResolutionError, -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_server_error",
             title = "Internal Server error",
             detail = "An internal error occurred."
         )
 
         ConfirmError.InvalidRequestedByError -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
-            code = "not_authorized",
             title = "Party not authorized",
             detail = "RequestedBy must match the authorized party",
         )
 
         ConfirmError.IllegalStateError -> buildApiErrorResponse(
             status = HttpStatusCode.NotFound,
-            code = "invalid_status_state",
             title = "Invalid status state",
             detail = "Document must be in 'Pending' status to confirm."
         )
 
         ConfirmError.ExpiredError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "expired_status_transition",
             title = "Document has expired",
             detail = "Document validity period has passed"
         )

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/CreateError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/CreateError.kt
@@ -22,14 +22,12 @@ fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollectio
     when (this) {
         is CreateError.BusinessValidationError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "business_validation_error",
             title = "Business validation error",
             detail = this.message
         )
 
         is CreateError.AuthorizationError -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
-            code = "not_authorized",
             title = "Party not authorized",
             detail = "RequestedBy must match the authorized party",
         )
@@ -41,7 +39,6 @@ fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollectio
         CreateError.RequestedFromPartyError,
         CreateError.RequestedToPartyError -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_server_error",
             title = "Internal server error",
             detail = "An internal error occurred."
         )

--- a/src/main/kotlin/no/elhub/auth/features/grants/consume/ConsumeError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/consume/ConsumeError.kt
@@ -17,42 +17,36 @@ fun ConsumeError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollecti
     when (this) {
         ConsumeError.GrantNotFound -> buildApiErrorResponse(
             status = HttpStatusCode.NotFound,
-            code = "not_found",
             title = "Not found",
             detail = "Grant could not be found"
         )
 
         ConsumeError.PersistenceError -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_server_error",
             title = "Internal server error",
             detail = "An internal error occurred."
         )
 
         ConsumeError.NotAuthorized -> buildApiErrorResponse(
             status = HttpStatusCode.Unauthorized,
-            code = "not_authorized",
             title = "Not authorized",
             detail = "Not authorized for this endpoint."
         )
 
         ConsumeError.IllegalStateError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "illegal_status_state",
             title = "Illegal status state",
             detail = "Grant must be 'Active' to get consumed"
         )
 
         ConsumeError.IllegalTransitionError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "invalid_status_transition",
             title = "Invalid status transition",
             detail = "Only 'Exhausted' status is allowed."
         )
 
         ConsumeError.ExpiredError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "expired_status_transition",
             title = "Grant has expired",
             detail = "Grant validity period has passed"
         )

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/CreateError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/CreateError.kt
@@ -21,7 +21,6 @@ fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollectio
     when (this) {
         CreateError.AuthorizationError -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
-            code = "not_authorized",
             title = "Party not authorized",
             detail = "RequestedBy must match the authorized party",
         )
@@ -31,7 +30,6 @@ fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollectio
         CreateError.RequestedByPartyError,
         CreateError.MappingError -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_server_error",
             title = "Internal server error",
             detail = "An internal error occurred."
         )
@@ -39,7 +37,6 @@ fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollectio
         is CreateError.ValidationError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
             title = "Validation error",
-            code = this.reason.code,
             detail = this.reason.message,
         )
     }

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/UpdateError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/UpdateError.kt
@@ -22,35 +22,30 @@ fun UpdateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollectio
         UpdateError.GrantCreationError,
         UpdateError.ScopeReadError, -> buildApiErrorResponse(
             status = HttpStatusCode.InternalServerError,
-            code = "internal_server_error",
             title = "Internal server error",
             detail = "An internal error occurred."
         )
 
         UpdateError.IllegalTransitionError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "invalid_status_transition",
             title = "Invalid status transition",
             detail = "Only 'Accepted' and 'Rejected' statuses are allowed."
         )
 
         UpdateError.AlreadyProcessed -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "invalid_status_state",
             title = "Invalid status state",
             detail = "Request must be in 'Pending' status to update."
         )
 
         UpdateError.Expired -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
-            code = "expired_status_transition",
             title = "Request has expired",
             detail = "Request validity period has passed"
         )
 
         UpdateError.NotAuthorizedError -> buildApiErrorResponse(
             status = HttpStatusCode.Unauthorized,
-            code = "not_authorized",
             title = "Not authorized",
             detail = "Not authorized for this endpoint."
         )

--- a/src/test/kotlin/no/elhub/auth/features/common/auth/AuthErrorJsonApiResponseTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/common/auth/AuthErrorJsonApiResponseTest.kt
@@ -6,36 +6,31 @@ import io.ktor.http.HttpStatusCode
 
 class AuthErrorJsonApiResponseTest : FunSpec({
 
-    data class Expectation(val status: HttpStatusCode, val code: String, val title: String, val detail: String)
+    data class Expectation(val status: HttpStatusCode, val title: String, val detail: String)
 
     listOf(
         AuthError.MissingAuthorizationHeader to Expectation(
             status = HttpStatusCode.Unauthorized,
-            code = "missing_authorization",
             title = "Missing authorization",
             detail = "Bearer token is required in the Authorization header."
         ),
         AuthError.InvalidAuthorizationHeader to Expectation(
             status = HttpStatusCode.Unauthorized,
-            code = "invalid_authorization_header",
             title = "Invalid authorization header",
             detail = "Authorization header must use the Bearer scheme."
         ),
         AuthError.MissingSenderGlnHeader to Expectation(
             status = HttpStatusCode.BadRequest,
-            code = "missing_sender_gln",
             title = "Missing senderGLN header",
             detail = "SenderGLN header is required for authorization."
         ),
         AuthError.InvalidToken to Expectation(
             status = HttpStatusCode.Unauthorized,
-            code = "invalid_token",
             title = "Invalid token",
             detail = "Token could not be verified."
         ),
         AuthError.ActingFunctionNotSupported to Expectation(
             status = HttpStatusCode.Forbidden,
-            code = "unsupported_party_type",
             title = "Unsupported party type",
             detail = "The party type you are authorized as is not supported for this endpoint."
         )
@@ -49,7 +44,6 @@ class AuthErrorJsonApiResponseTest : FunSpec({
                 this.status shouldBe expected.status.value.toString()
                 title shouldBe expected.title
                 detail shouldBe expected.detail
-                code shouldBe expected.code
             }
         }
     }
@@ -70,7 +64,6 @@ class AuthErrorJsonApiResponseTest : FunSpec({
                 this.status shouldBe HttpStatusCode.InternalServerError.value.toString()
                 title shouldBe "Internal server error"
                 detail shouldBe "An internal error occurred."
-                code shouldBe "internal_server_error"
             }
         }
     }

--- a/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
@@ -337,7 +337,6 @@ class AuthorizationDocumentRouteTest :
                         size shouldBe 1
                         this[0].apply {
                             status shouldBe HttpStatusCode.Forbidden.value.toString()
-                            code shouldBe "not_authorized"
                             title shouldBe "Party not authorized"
                             detail shouldBe "The party is not allowed to access this resource"
                         }
@@ -567,7 +566,6 @@ class AuthorizationDocumentRouteTest :
                         size shouldBe 1
                         this[0].apply {
                             status shouldBe "400"
-                            code shouldBe "bad_request"
                             title shouldBe "Bad request"
                             detail shouldBe "Missing User-Agent header"
                         }

--- a/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
@@ -128,7 +128,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "invalid_input"
                         title shouldBe "Invalid input"
                         detail shouldBe "The provided payload did not satisfy the expected format"
                     }
@@ -146,7 +145,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "not_authorized"
                         title shouldBe "Party not authorized"
                         detail shouldBe "The party is not allowed to access this resource"
                     }
@@ -163,7 +161,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "401"
-                        code shouldBe "missing_authorization"
                         title shouldBe "Missing authorization"
                         detail shouldBe "Bearer token is required in the Authorization header."
                     }
@@ -230,7 +227,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "not_authorized"
                         title shouldBe "Party not authorized"
                         detail shouldBe "The party is not allowed to access this resource"
                     }
@@ -248,7 +244,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "404"
-                        code shouldBe "not_found"
                         title shouldBe "Not found"
                         detail shouldBe "The requested resource could not be found"
                     }
@@ -365,7 +360,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "401"
-                        code shouldBe "missing_authorization"
                         title shouldBe "Missing authorization"
                         detail shouldBe "Bearer token is required in the Authorization header."
                     }
@@ -383,7 +377,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "not_authorized"
                         title shouldBe "Party not authorized"
                         detail shouldBe "The party is not allowed to access this resource"
                     }
@@ -411,7 +404,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "not_authorized"
                         title shouldBe "Party not authorized"
                         detail shouldBe "The party is not allowed to access this resource"
                     }
@@ -429,7 +421,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "invalid_input"
                         title shouldBe "Invalid input"
                         detail shouldBe "The provided payload did not satisfy the expected format"
                     }
@@ -447,7 +438,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "404"
-                        code shouldBe "not_found"
                         title shouldBe "Not found"
                         detail shouldBe "The requested resource could not be found"
                     }
@@ -639,7 +629,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "illegal_status_state"
                         title shouldBe "Illegal status state"
                         detail shouldBe "Grant must be 'Active' to get consumed"
                     }
@@ -668,7 +657,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "expired_status_transition"
                         title shouldBe "Grant has expired"
                         detail shouldBe "Grant validity period has passed"
                     }
@@ -697,7 +685,6 @@ class AuthorizationGrantRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "invalid_status_transition"
                         title shouldBe "Invalid status transition"
                         detail shouldBe "Only 'Exhausted' status is allowed."
                     }

--- a/src/test/kotlin/no/elhub/auth/features/requests/AuthorizationRequestRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/AuthorizationRequestRouteTest.kt
@@ -325,7 +325,6 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "404"
-                        code shouldBe "not_found"
                         title shouldBe "Not found"
                         detail shouldBe "The requested resource could not be found"
                     }
@@ -343,7 +342,6 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "not_authorized"
                         title shouldBe "Party not authorized"
                         detail shouldBe "The party is not allowed to access this resource"
                     }
@@ -360,7 +358,6 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "not_authorized"
                         title shouldBe "Party not authorized"
                         detail shouldBe "The party is not allowed to access this resource"
                     }
@@ -520,7 +517,7 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "missing_requested_from_name"
+
                         title shouldBe "Validation error"
                         detail shouldBe "Requested from name is missing"
                     }
@@ -573,7 +570,6 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "403"
-                        code shouldBe "unsupported_party_type"
                         title shouldBe "Unsupported party type"
                         detail shouldBe "The party type you are authorized as is not supported for this endpoint."
                     }
@@ -609,7 +605,6 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "expired_status_transition"
                         title shouldBe "Request has expired"
                         detail shouldBe "Request validity period has passed"
                     }
@@ -870,7 +865,6 @@ class AuthorizationRequestRouteTest : FunSpec({
                     size shouldBe 1
                     this[0].apply {
                         status shouldBe "400"
-                        code shouldBe "invalid_status_transition"
                         title shouldBe "Invalid status transition"
                         detail shouldBe "Only 'Accepted' and 'Rejected' statuses are allowed."
                     }


### PR DESCRIPTION
The code attribute is intended for consumer-side error handling and programmatic branching. We haven't agreed on stable
semantics, so we're removing it for now to avoid locking in an under-specified contract. We still keep code as an optional
field in the API contract, but should only re-introduce it once consistent meanings are defined and documented across
endpoints.
