### PR TITLE
Correct mismatch in spec and actual response for /scope [patch]

### DIFF
--- a/src/main/resources/static/schemas/elhub-common.schema.json
+++ b/src/main/resources/static/schemas/elhub-common.schema.json
@@ -58,30 +58,22 @@
     "resourceReference": {
       "type": "object",
       "properties": {
-        "data": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "description": "A reference to an Elhub resource object.",
-              "enum": ["MeteringPoint"]
-            },
-            "id": {
-              "type": "string",
-              "description": "The unique identifier of the linked resource."
-            }
-          },
-          "examples": [
-            {
-              "data": {
-                "type": "MeteringPoint",
-                "id": "12345678901234"
-              }
-            }
-          ]
+        "type": {
+          "description": "A reference to an Elhub resource object.",
+          "enum": ["MeteringPoint"]
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the linked resource."
         }
       },
-      "required": ["data"]
+      "examples": [
+        {
+          "type": "metering-points",
+          "id": "12345678901234"
+        }
+      ],
+      "required": ["type", "id"]
     },
     "createdAt": {
       "type": "string",


### PR DESCRIPTION
The openApi spec is currently showing wrong response (see the nested `data` field) 
<img width="587" height="552" alt="image" src="https://github.com/user-attachments/assets/a212e83d-bc77-4c21-9a1d-1a1539c8ce11" />
## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
