### PR TITLE
Polish the OpenApi specification [patch]

### DIFF
--- a/src/main/resources/static/schemas/documents/authorization-document-resource.schema.json
+++ b/src/main/resources/static/schemas/documents/authorization-document-resource.schema.json
@@ -63,6 +63,11 @@
         },
         "links": {
           "$ref": "authorization-document-common.schema.json#/$defs/links",
+          "examples": [
+            {
+              "self": "/access/v0/authorization-documents/123e4567-e89b-12d3-a456-426614174000"
+            }
+          ],
           "required": [
             "self",
             "file"
@@ -72,7 +77,12 @@
     },
     "links": {
       "description": "Link members related to the primary data.",
-      "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks"
+      "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
+      "examples": [
+        {
+          "self": "/access/v0/authorization-documents/123e4567-e89b-12d3-a456-426614174000"
+        }
+      ]
     },
     "meta": {
       "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"

--- a/src/main/resources/static/schemas/elhub-common.schema.json
+++ b/src/main/resources/static/schemas/elhub-common.schema.json
@@ -69,7 +69,7 @@
       },
       "examples": [
         {
-          "type": "metering-points",
+          "type": "MeteringPoint",
           "id": "12345678901234"
         }
       ],

--- a/src/main/resources/static/schemas/grants/authorization-grant-collection.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-grant-collection.schema.json
@@ -17,7 +17,7 @@
       "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
       "examples": [
         {
-          "self": "/access/v0/authorization-documents"
+          "self": "/access/v0/authorization-grants"
         }
       ]
     },

--- a/src/main/resources/static/schemas/grants/authorization-grant-common.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-grant-common.schema.json
@@ -122,7 +122,7 @@
                 },
                 "examples": [
                   {
-                    "id": "scope-12345",
+                    "id": "456e4567-e89b-12d3-a456-426614174000",
                     "type": "AuthorizationScope"
                   }
                 ]

--- a/src/main/resources/static/schemas/grants/authorization-grant-resource.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-grant-resource.schema.json
@@ -49,7 +49,12 @@
     },
     "links": {
       "description": "Link members related to the primary data.",
-      "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks"
+      "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
+      "examples": [
+        {
+          "self": "/access/v0/authorization-grants/123e4567-e89b-12d3-a456-426614174000"
+        }
+      ]
     },
     "meta": {
       "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"

--- a/src/main/resources/static/schemas/grants/authorization-scope-collection.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-scope-collection.schema.json
@@ -17,7 +17,7 @@
       "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
       "examples": [
         {
-          "self": "/access/v0/authorization-documents"
+          "self": "/access/v0/authorization-grants/123e4567-e89b-12d3-a456-426614174000/scopes"
         }
       ]
     },

--- a/src/main/resources/static/schemas/grants/authorization-scope-resource.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-scope-resource.schema.json
@@ -14,7 +14,10 @@
       ],
       "properties": {
         "id": {
-          "$ref": "authorization-grant-common.schema.json#/$defs/id"
+          "$ref": "authorization-grant-common.schema.json#/$defs/id",
+          "examples": [
+            "456e4567-e89b-12d3-a456-426614174000"
+          ]
         },
         "type": {
           "$ref": "authorization-grant-common.schema.json#/$defs/scopeType"
@@ -43,7 +46,12 @@
     },
     "links": {
       "description": "Link members related to the primary data.",
-      "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks"
+      "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
+      "examples": [
+        {
+          "self": "/access/v0/authorization-grants/123e4567-e89b-12d3-a456-426614174000/scopes/456e4567-e89b-12d3-a456-426614174000"
+        }
+      ]
     },
     "meta": {
       "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"

--- a/src/main/resources/static/schemas/requests/authorization-request-collection.schema.json
+++ b/src/main/resources/static/schemas/requests/authorization-request-collection.schema.json
@@ -16,7 +16,9 @@
       "description": "Link members related to the collection (e.g., pagination).",
       "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
       "examples": [
-        "/access/v0/authorization-requests"
+        {
+          "self": "/access/v0/authorization-requests"
+        }
       ]
     },
     "meta": {

--- a/src/main/resources/static/schemas/requests/authorization-request-common.schema.json
+++ b/src/main/resources/static/schemas/requests/authorization-request-common.schema.json
@@ -143,7 +143,9 @@
           "format": "uri",
           "description": "A link to this resource.",
           "examples": [
-            "/access/v0/authorization-requests/123e4567-e89b-12d3-a456-426614174000"
+            {
+              "self": "/access/v0/authorization-requests/123e4567-e89b-12d3-a456-426614174000"
+            }
           ]
         }
       },

--- a/src/main/resources/static/schemas/requests/authorization-request-resource.schema.json
+++ b/src/main/resources/static/schemas/requests/authorization-request-resource.schema.json
@@ -62,13 +62,12 @@
           }
         },
         "links": {
-          "$ref": "authorization-request-common.schema.json#/$defs/links",
-          "required": [
-            "self"
-          ]
-        },
-        "additionalProperties": false
-      }
+          "description": "Links related to the primary data.",
+          "$ref": "../json-api-framework.schema.json#/$defs/topLevelLinks",
+          "examples": [ { "self": "/access/v0/authorization-requests/123e4567-e89b-12d3-a456-426614174000" }]
+        }
+      },
+      "additionalProperties": false
     },
     "links": {
       "description": "Links related to the primary data.",


### PR DESCRIPTION
## 📝 Description

This PR contains fixing:
- Correct `type` in the example for `/authorization-grants/{id}/scopes`
<img width="277" height="140" alt="image" src="https://github.com/user-attachments/assets/ab0a90aa-3003-41b7-8016-3fb22020b3c1" />

- Remove the `additionalProperties: 
<img width="610" height="102" alt="image" src="https://github.com/user-attachments/assets/039a22bb-fe16-40c1-89cb-1805d9242f4e" />

- Fix unresolved `links` examples: 
<img width="1250" height="87" alt="image" src="https://github.com/user-attachments/assets/356aff7a-a4a2-4a44-9f59-995e727509c2" />


## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
