### PR TITLE
Disable triggering deploy PR on vcs change for MT1 [patch]

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -55,7 +55,7 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
                 gitOps {
                     clusters = setOf(KubeCluster.MARKET_TRIAL_1)
                     gitOpsRepository = gitOpsRepo
-                }.triggerOnVcsChange()
+                }
 
                 gitOps {
                     clusters = setOf(KubeCluster.TEST13)


### PR DESCRIPTION
## 📝 Description

We should trigger the deploy to MT1 manually when we're ready. This is have more control and avoid spamming the ops team.

## 📋 Checklist

* ✅ Lint checks passed on local machine.
* ✅ Unit tests passed on local machine.
