### PR TITLE
feat: Add wow-team as CODEOWNERS for our business processes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,9 @@
 
 # Default Repository Owner
 * @elhub/devxp @elhub/auth
+
+# Business process modules
+/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofsupplier/ @elhub/wow
+/src/test/kotlin/no/elhub/auth/features/businessprocesses/changeofsupplier/ @elhub/wow
+/src/main/kotlin/no/elhub/auth/features/businessprocesses/movein/ @elhub/wow
+/src/test/kotlin/no/elhub/auth/features/businessprocesses/movein/ @elhub/wow


### PR DESCRIPTION
I think it makes sense for WOW as a team to be CODEOWNERS of our own business processes (MoveIn and ChangeOfSupplier atm)

WDYT?