### PR TITLE
refactor(auth): pass resolved authorization parties to business layer

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/BusinessProcessesModule.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/BusinessProcessesModule.kt
@@ -7,14 +7,13 @@ import no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplier
 import no.elhub.auth.features.documents.common.DocumentBusinessHandler
 import no.elhub.auth.features.documents.common.ProxyDocumentBusinessHandler
 import no.elhub.auth.features.requests.common.ProxyRequestBusinessHandler
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 
 fun Application.businessProcessesModule() {
     dependencies {
         provide<ChangeOfBalanceSupplierBusinessHandler> {
             ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = resolve(),
-                personService = resolve(),
                 organisationsService = resolve(),
                 stromprisService = resolve(),
                 edielService = resolve(),
@@ -26,7 +25,6 @@ fun Application.businessProcessesModule() {
         provide<MoveInAndChangeOfBalanceSupplierBusinessHandler> {
             MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = resolve(),
-                personService = resolve(),
                 organisationsService = resolve(),
                 stromprisService = resolve(),
                 edielService = resolve(),

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/ChangeOfBalanceSupplierBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/ChangeOfBalanceSupplierBusinessHandler.kt
@@ -27,18 +27,17 @@ import no.elhub.auth.features.businessprocesses.structuredata.organisations.Orga
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.PartyStatus
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.PartyType
 import no.elhub.auth.features.common.CreateScopeData
-import no.elhub.auth.features.common.person.PersonService
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.common.DocumentBusinessHandler
 import no.elhub.auth.features.documents.create.command.DocumentCommand
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.grants.AuthorizationScope
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.create.command.RequestCommand
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
 
 private const val REGEX_NUMBERS_LETTERS_SYMBOLS = "^[a-zA-Z0-9_.-]*$"
 private const val REGEX_REQUESTED_FROM = REGEX_NUMBERS_LETTERS_SYMBOLS
@@ -56,7 +55,6 @@ private fun changeOfBalanceSupplierGrantValidTo() =
 
 class ChangeOfBalanceSupplierBusinessHandler(
     private val meteringPointsService: MeteringPointsService,
-    private val personService: PersonService,
     private val organisationsService: OrganisationsService,
     private val stromprisService: StromprisService,
     private val edielService: EdielService,
@@ -65,7 +63,7 @@ class ChangeOfBalanceSupplierBusinessHandler(
     private val validateBalanceSupplierContractName: Boolean
 ) : RequestBusinessHandler, DocumentBusinessHandler {
 
-    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestModel): Either<BusinessProcessError, RequestCommand> =
+    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestBusinessModel): Either<BusinessProcessError, RequestCommand> =
         either {
             val model = createRequestModel.toChangeOfBalanceSupplierBusinessModel()
             validateRequest(model)
@@ -94,7 +92,7 @@ class ChangeOfBalanceSupplierBusinessHandler(
             return Unit.right()
         }
 
-        val redirectUriFromEdiel = edielService.getPartyRedirect(model.requestedBy.idValue).mapLeft { err ->
+        val redirectUriFromEdiel = edielService.getPartyRedirect(model.requestedBy.id).mapLeft { err ->
             return when (err) {
                 ClientError.NotFound -> ChangeOfBalanceSupplierValidationError.InvalidRedirectURI.left()
 
@@ -121,7 +119,7 @@ class ChangeOfBalanceSupplierBusinessHandler(
             validFrom = todayOslo()
         )
 
-    override suspend fun validateAndReturnDocumentCommand(model: CreateDocumentModel): Either<BusinessProcessError, DocumentCommand> =
+    override suspend fun validateAndReturnDocumentCommand(model: CreateDocumentBusinessModel): Either<BusinessProcessError, DocumentCommand> =
         either {
             val businessModel = model.toChangeOfBalanceSupplierBusinessModel()
             validate(businessModel)
@@ -159,22 +157,13 @@ class ChangeOfBalanceSupplierBusinessHandler(
             return ChangeOfBalanceSupplierValidationError.InvalidMeteringPointId.left()
         }
 
-        if (model.requestedFrom.idValue.isBlank()) {
+        if (model.requestedFrom.id.isBlank()) {
             return ChangeOfBalanceSupplierValidationError.MissingRequestedFrom.left()
         }
 
-        if (!model.requestedFrom.idValue.matches(Regex(REGEX_REQUESTED_FROM))) {
-            return ChangeOfBalanceSupplierValidationError.InvalidRequestedFrom.left()
-        }
-
-        // temporary mapping until model has elhubInternalId instead of NIN
-        val endUserElhubInternalId =
-            personService.findOrCreateByNin(model.requestedFrom.idValue).getOrNull()?.internalId
-                ?: return ChangeOfBalanceSupplierValidationError.RequestedFromNotFound.left()
-
         val meteringPoint = meteringPointsService.getMeteringPointByIdAndElhubInternalId(
             meteringPointId = model.requestedForMeteringPointId,
-            elhubInternalId = endUserElhubInternalId.toString()
+            elhubInternalId = model.requestedFrom.id
         ).mapLeft { err ->
             return when (err) {
                 ClientError.NotFound -> ChangeOfBalanceSupplierValidationError.MeteringPointNotFound.left()
@@ -198,16 +187,16 @@ class ChangeOfBalanceSupplierBusinessHandler(
             return ChangeOfBalanceSupplierValidationError.MissingMeteringPointAddress.left()
         }
 
-        if (model.requestedBy.idValue.isBlank()) {
+        if (model.requestedBy.id.isBlank()) {
             return ChangeOfBalanceSupplierValidationError.MissingRequestedBy.left()
         }
 
-        if (!model.requestedBy.idValue.matches(Regex(REGEX_REQUESTED_BY))) {
+        if (!model.requestedBy.id.matches(Regex(REGEX_REQUESTED_BY))) {
             return ChangeOfBalanceSupplierValidationError.InvalidRequestedBy.left()
         }
 
         val party = organisationsService.getPartyByIdAndPartyType(
-            partyId = model.requestedBy.idValue,
+            partyId = model.requestedBy.id,
             partyType = PartyType.BalanceSupplier
         ).mapLeft { err ->
             return when (err) {
@@ -224,7 +213,7 @@ class ChangeOfBalanceSupplierBusinessHandler(
             return ChangeOfBalanceSupplierValidationError.NotActiveRequestedBy.left()
         }
 
-        if (model.requestedTo.idValue != model.requestedFrom.idValue) {
+        if (model.requestedTo.id != model.requestedFrom.id) {
             return ChangeOfBalanceSupplierValidationError.RequestedToRequestedFromMismatch.left()
         }
 
@@ -271,9 +260,6 @@ class ChangeOfBalanceSupplierBusinessHandler(
         )
 
         return ChangeOfBalanceSupplierBusinessCommand(
-            requestedFrom = model.requestedFrom,
-            requestedBy = model.requestedBy,
-            requestedTo = model.requestedTo,
             validTo = changeOfBalanceSupplierRequestValidTo(),
             scopes = scopes,
             meta = meta,

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/domain/ChangeOfBalanceSupplierBusinessCommand.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/domain/ChangeOfBalanceSupplierBusinessCommand.kt
@@ -2,7 +2,6 @@ package no.elhub.auth.features.businessprocesses.changeofbalancesupplier.domain
 
 import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.common.CreateScopeData
-import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.create.command.DocumentCommand
@@ -16,9 +15,6 @@ import no.elhub.auth.features.requests.create.command.withTextVersion
 private const val CHANGE_OF_BALANCE_SUPPLIER_TEXT_VERSION = "v1"
 
 data class ChangeOfBalanceSupplierBusinessCommand(
-    val requestedFrom: PartyIdentifier,
-    val requestedBy: PartyIdentifier,
-    val requestedTo: PartyIdentifier,
     val validTo: LocalDate,
     val scopes: List<CreateScopeData>,
     val meta: ChangeOfBalanceSupplierBusinessMeta,
@@ -56,9 +52,6 @@ data class ChangeOfBalanceSupplierBusinessMeta(
 fun ChangeOfBalanceSupplierBusinessCommand.toRequestCommand(): RequestCommand =
     RequestCommand(
         type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-        requestedBy = this.requestedBy,
-        requestedFrom = this.requestedFrom,
-        requestedTo = this.requestedTo,
         scopes = this.scopes,
         validTo = this.validTo.toTimeZoneOffsetDateTimeAtStartOfDay(),
         meta = this.meta,
@@ -67,9 +60,6 @@ fun ChangeOfBalanceSupplierBusinessCommand.toRequestCommand(): RequestCommand =
 fun ChangeOfBalanceSupplierBusinessCommand.toDocumentCommand(): DocumentCommand =
     DocumentCommand(
         type = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
-        requestedFrom = this.requestedFrom,
-        requestedTo = this.requestedTo,
-        requestedBy = this.requestedBy,
         scopes = this.scopes,
         validTo = this.validTo.toTimeZoneOffsetDateTimeAtStartOfDay(),
         meta = this.meta,

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/domain/ChangeOfBalanceSupplierBusinessModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/domain/ChangeOfBalanceSupplierBusinessModel.kt
@@ -1,16 +1,16 @@
 package no.elhub.auth.features.businessprocesses.changeofbalancesupplier.domain
 
-import no.elhub.auth.features.common.party.PartyIdentifier
+import no.elhub.auth.features.common.party.AuthorizationParty
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.create.dto.toSupportedLanguage
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.filegenerator.SupportedLanguage
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 
 data class ChangeOfBalanceSupplierBusinessModel(
     val language: SupportedLanguage = SupportedLanguage.DEFAULT,
-    val requestedBy: PartyIdentifier,
-    val requestedFrom: PartyIdentifier,
-    val requestedTo: PartyIdentifier,
+    val requestedBy: AuthorizationParty,
+    val requestedFrom: AuthorizationParty,
+    val requestedTo: AuthorizationParty,
     val requestedFromName: String,
     val requestedForMeteringPointId: String,
     val requestedForMeteringPointAddress: String,
@@ -19,11 +19,11 @@ data class ChangeOfBalanceSupplierBusinessModel(
     val redirectURI: String? = null,
 )
 
-fun CreateRequestModel.toChangeOfBalanceSupplierBusinessModel(): ChangeOfBalanceSupplierBusinessModel =
+fun CreateRequestBusinessModel.toChangeOfBalanceSupplierBusinessModel(): ChangeOfBalanceSupplierBusinessModel =
     ChangeOfBalanceSupplierBusinessModel(
-        requestedBy = this.meta.requestedBy,
-        requestedFrom = this.meta.requestedFrom,
-        requestedTo = this.meta.requestedTo,
+        requestedBy = this.requestedBy,
+        requestedFrom = this.requestedFrom,
+        requestedTo = this.requestedTo,
         requestedFromName = this.meta.requestedFromName,
         requestedForMeteringPointId = this.meta.requestedForMeteringPointId,
         requestedForMeteringPointAddress = this.meta.requestedForMeteringPointAddress,
@@ -32,12 +32,12 @@ fun CreateRequestModel.toChangeOfBalanceSupplierBusinessModel(): ChangeOfBalance
         redirectURI = this.meta.redirectURI,
     )
 
-fun CreateDocumentModel.toChangeOfBalanceSupplierBusinessModel(): ChangeOfBalanceSupplierBusinessModel =
+fun CreateDocumentBusinessModel.toChangeOfBalanceSupplierBusinessModel(): ChangeOfBalanceSupplierBusinessModel =
     ChangeOfBalanceSupplierBusinessModel(
         language = this.meta.language.toSupportedLanguage(),
-        requestedBy = this.meta.requestedBy,
-        requestedFrom = this.meta.requestedFrom,
-        requestedTo = this.meta.requestedTo,
+        requestedBy = this.requestedBy,
+        requestedFrom = this.requestedFrom,
+        requestedTo = this.requestedTo,
         requestedFromName = this.meta.requestedFromName,
         requestedForMeteringPointId = this.meta.requestedForMeteringPointId,
         requestedForMeteringPointAddress = this.meta.requestedForMeteringPointAddress,

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/MoveInAndChangeOfBalanceSupplierBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/MoveInAndChangeOfBalanceSupplierBusinessHandler.kt
@@ -27,18 +27,17 @@ import no.elhub.auth.features.businessprocesses.structuredata.organisations.Orga
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.PartyStatus
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.PartyType
 import no.elhub.auth.features.common.CreateScopeData
-import no.elhub.auth.features.common.person.PersonService
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.common.DocumentBusinessHandler
 import no.elhub.auth.features.documents.create.command.DocumentCommand
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.grants.AuthorizationScope
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.create.command.RequestCommand
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
 
 private const val REGEX_NUMBERS_LETTERS_SYMBOLS = "^[a-zA-Z0-9_.-]*$"
 private const val REGEX_REQUESTED_FROM = REGEX_NUMBERS_LETTERS_SYMBOLS
@@ -57,7 +56,6 @@ private fun moveInGrantValidTo() = todayOslo().plus(DatePeriod(years = MOVE_IN_G
 class MoveInAndChangeOfBalanceSupplierBusinessHandler(
     private val organisationsService: OrganisationsService,
     private val meteringPointsService: MeteringPointsService,
-    private val personService: PersonService,
     private val stromprisService: StromprisService,
     private val edielService: EdielService,
     private val edielEnvironment: EdielEnvironment,
@@ -66,7 +64,7 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
 ) : RequestBusinessHandler,
     DocumentBusinessHandler {
 
-    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestModel): Either<BusinessProcessError, RequestCommand> =
+    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestBusinessModel): Either<BusinessProcessError, RequestCommand> =
         either {
             val model = createRequestModel.toMoveInAndChangeOfBalanceSupplierBusinessModel()
             validateRequest(model).mapLeft { it.toBusinessError() }.bind().toRequestCommand()
@@ -92,7 +90,7 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
             return Unit.right()
         }
 
-        val redirectUriFromEdiel = edielService.getPartyRedirect(model.requestedBy.idValue).mapLeft { err ->
+        val redirectUriFromEdiel = edielService.getPartyRedirect(model.requestedBy.id).mapLeft { err ->
             return when (err) {
                 ClientError.NotFound -> MoveInAndChangeOfBalanceSupplierValidationError.InvalidRedirectURI.left()
 
@@ -120,7 +118,7 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
         return buildCreateGrantProperties(propertyMap, ALLOWED_GRANT_PROPERTY_KEYS)
     }
 
-    override suspend fun validateAndReturnDocumentCommand(model: CreateDocumentModel): Either<BusinessProcessError, DocumentCommand> =
+    override suspend fun validateAndReturnDocumentCommand(model: CreateDocumentBusinessModel): Either<BusinessProcessError, DocumentCommand> =
         either {
             val businessModel = model.toMoveInAndChangeOfBalanceSupplierBusinessModel()
             validate(businessModel).mapLeft { it.toBusinessError() }.bind().toDocumentCommand()
@@ -172,22 +170,13 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
             return MoveInAndChangeOfBalanceSupplierValidationError.MissingMeteringPointAddress.left()
         }
 
-        if (model.requestedFrom.idValue.isBlank()) {
+        if (model.requestedFrom.id.isBlank()) {
             return MoveInAndChangeOfBalanceSupplierValidationError.MissingRequestedFrom.left()
         }
 
-        if (!model.requestedFrom.idValue.matches(Regex(REGEX_REQUESTED_FROM))) {
-            return MoveInAndChangeOfBalanceSupplierValidationError.InvalidRequestedFrom.left()
-        }
-
-        // temporary mapping until model has elhubInternalId instead of NIN
-        val endUserElhubInternalId =
-            personService.findOrCreateByNin(model.requestedFrom.idValue).getOrNull()?.internalId
-                ?: return MoveInAndChangeOfBalanceSupplierValidationError.RequestedFromNotFound.left()
-
         val meteringPoint = meteringPointsService.getMeteringPointByIdAndElhubInternalId(
             meteringPointId = model.requestedForMeteringPointId,
-            elhubInternalId = endUserElhubInternalId.toString()
+            elhubInternalId = model.requestedFrom.id
         ).mapLeft { err ->
             return when (err) {
                 ClientError.NotFound -> MoveInAndChangeOfBalanceSupplierValidationError.MeteringPointNotFound.left()
@@ -210,16 +199,16 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
             }
         }
 
-        if (model.requestedBy.idValue.isBlank()) {
+        if (model.requestedBy.id.isBlank()) {
             return MoveInAndChangeOfBalanceSupplierValidationError.MissingRequestedBy.left()
         }
 
-        if (!model.requestedBy.idValue.matches(Regex(REGEX_REQUESTED_BY))) {
+        if (!model.requestedBy.id.matches(Regex(REGEX_REQUESTED_BY))) {
             return MoveInAndChangeOfBalanceSupplierValidationError.InvalidRequestedBy.left()
         }
 
         val party = organisationsService.getPartyByIdAndPartyType(
-            model.requestedBy.idValue,
+            model.requestedBy.id,
             PartyType.BalanceSupplier
         )
             .mapLeft { err ->
@@ -238,7 +227,7 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
             return MoveInAndChangeOfBalanceSupplierValidationError.NotActiveRequestedBy.left()
         }
 
-        if (model.requestedTo.idValue != model.requestedFrom.idValue) {
+        if (model.requestedTo.id != model.requestedFrom.id) {
             return MoveInAndChangeOfBalanceSupplierValidationError.RequestedToRequestedFromMismatch.left()
         }
 
@@ -292,9 +281,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandler(
         )
 
         return MoveInAndChangeOfBalanceSupplierBusinessCommand(
-            requestedFrom = model.requestedFrom,
-            requestedBy = model.requestedBy,
-            requestedTo = model.requestedTo,
             validTo = moveInRequestValidTo(),
             scopes = scopes,
             meta = meta,

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/domain/MoveInAndChangeOfBalanceSupplierBusinessCommand.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/domain/MoveInAndChangeOfBalanceSupplierBusinessCommand.kt
@@ -2,7 +2,6 @@ package no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplie
 
 import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.common.CreateScopeData
-import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.create.command.DocumentCommand
@@ -16,9 +15,6 @@ import no.elhub.auth.features.requests.create.command.withTextVersion
 private const val MOVE_IN_AND_CHANGE_OF_BALANCE_SUPPLIER_TEXT_VERSION = "v1"
 
 data class MoveInAndChangeOfBalanceSupplierBusinessCommand(
-    val requestedFrom: PartyIdentifier,
-    val requestedBy: PartyIdentifier,
-    val requestedTo: PartyIdentifier,
     val validTo: LocalDate,
     val scopes: List<CreateScopeData>,
     val meta: MoveInAndChangeOfBalanceSupplierBusinessMeta,
@@ -58,9 +54,6 @@ data class MoveInAndChangeOfBalanceSupplierBusinessMeta(
 fun MoveInAndChangeOfBalanceSupplierBusinessCommand.toRequestCommand(): RequestCommand =
     RequestCommand(
         type = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
-        requestedBy = this.requestedBy,
-        requestedFrom = this.requestedFrom,
-        requestedTo = this.requestedTo,
         scopes = this.scopes,
         validTo = this.validTo.toTimeZoneOffsetDateTimeAtStartOfDay(),
         meta = this.meta,
@@ -69,9 +62,6 @@ fun MoveInAndChangeOfBalanceSupplierBusinessCommand.toRequestCommand(): RequestC
 fun MoveInAndChangeOfBalanceSupplierBusinessCommand.toDocumentCommand(): DocumentCommand =
     DocumentCommand(
         type = AuthorizationDocument.Type.MoveInAndChangeOfBalanceSupplierForPerson,
-        requestedFrom = this.requestedFrom,
-        requestedTo = this.requestedTo,
-        requestedBy = this.requestedBy,
         scopes = this.scopes,
         validTo = this.validTo.toTimeZoneOffsetDateTimeAtStartOfDay(),
         meta = this.meta,

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/domain/MoveInAndChangeOfBalanceSupplierBusinessModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/domain/MoveInAndChangeOfBalanceSupplierBusinessModel.kt
@@ -1,17 +1,17 @@
 package no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplier.domain
 
 import kotlinx.datetime.LocalDate
-import no.elhub.auth.features.common.party.PartyIdentifier
+import no.elhub.auth.features.common.party.AuthorizationParty
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.create.dto.toSupportedLanguage
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.filegenerator.SupportedLanguage
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 
 data class MoveInAndChangeOfBalanceSupplierBusinessModel(
     val language: SupportedLanguage = SupportedLanguage.DEFAULT,
-    val requestedBy: PartyIdentifier,
-    val requestedFrom: PartyIdentifier,
-    val requestedTo: PartyIdentifier,
+    val requestedBy: AuthorizationParty,
+    val requestedFrom: AuthorizationParty,
+    val requestedTo: AuthorizationParty,
     val requestedFromName: String,
     val requestedForMeteringPointId: String,
     val requestedForMeteringPointAddress: String,
@@ -21,11 +21,11 @@ data class MoveInAndChangeOfBalanceSupplierBusinessModel(
     val redirectURI: String? = null,
 )
 
-fun CreateRequestModel.toMoveInAndChangeOfBalanceSupplierBusinessModel(): MoveInAndChangeOfBalanceSupplierBusinessModel =
+fun CreateRequestBusinessModel.toMoveInAndChangeOfBalanceSupplierBusinessModel(): MoveInAndChangeOfBalanceSupplierBusinessModel =
     MoveInAndChangeOfBalanceSupplierBusinessModel(
-        requestedBy = this.meta.requestedBy,
-        requestedFrom = this.meta.requestedFrom,
-        requestedTo = this.meta.requestedTo,
+        requestedBy = this.requestedBy,
+        requestedFrom = this.requestedFrom,
+        requestedTo = this.requestedTo,
         requestedFromName = this.meta.requestedFromName,
         requestedForMeteringPointId = this.meta.requestedForMeteringPointId,
         requestedForMeteringPointAddress = this.meta.requestedForMeteringPointAddress,
@@ -35,12 +35,12 @@ fun CreateRequestModel.toMoveInAndChangeOfBalanceSupplierBusinessModel(): MoveIn
         redirectURI = this.meta.redirectURI,
     )
 
-fun CreateDocumentModel.toMoveInAndChangeOfBalanceSupplierBusinessModel(): MoveInAndChangeOfBalanceSupplierBusinessModel =
+fun CreateDocumentBusinessModel.toMoveInAndChangeOfBalanceSupplierBusinessModel(): MoveInAndChangeOfBalanceSupplierBusinessModel =
     MoveInAndChangeOfBalanceSupplierBusinessModel(
         language = this.meta.language.toSupportedLanguage(),
-        requestedBy = this.meta.requestedBy,
-        requestedFrom = this.meta.requestedFrom,
-        requestedTo = this.meta.requestedTo,
+        requestedBy = this.requestedBy,
+        requestedFrom = this.requestedFrom,
+        requestedTo = this.requestedTo,
         requestedFromName = this.meta.requestedFromName,
         requestedForMeteringPointId = this.meta.requestedForMeteringPointId,
         requestedForMeteringPointAddress = this.meta.requestedForMeteringPointAddress,

--- a/src/main/kotlin/no/elhub/auth/features/common/auth/PdpResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/auth/PdpResponse.kt
@@ -29,12 +29,7 @@ data class AuthInfo(
     val actingId: String? = null,
     val actingType: String? = null,
     val actingOrganisationNumber: String? = null,
-    val originalId: String? = null,
     val error: String? = null,
-    val originalOnBehalfOfFunction: String? = null,
-    val originalOnBehalfOfGLN: String? = null,
-    val originalSenderFunction: String? = null,
-    val originalSenderGLN: String? = null
 )
 
 @Serializable

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/CreateDocumentBusinessModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/CreateDocumentBusinessModel.kt
@@ -1,0 +1,25 @@
+package no.elhub.auth.features.documents.common
+
+import kotlinx.datetime.LocalDate
+import no.elhub.auth.features.common.party.AuthorizationParty
+import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.create.dto.SupportedLanguageDTO
+
+data class CreateDocumentBusinessModel(
+    val authorizedParty: AuthorizationParty,
+    val documentType: AuthorizationDocument.Type,
+    val requestedBy: AuthorizationParty,
+    val requestedFrom: AuthorizationParty,
+    val requestedTo: AuthorizationParty,
+    val meta: CreateDocumentBusinessMeta,
+)
+
+data class CreateDocumentBusinessMeta(
+    val requestedFromName: String,
+    val requestedForMeteringPointId: String,
+    val requestedForMeteringPointAddress: String,
+    val balanceSupplierName: String,
+    val balanceSupplierContractName: String,
+    val moveInDate: LocalDate? = null,
+    val language: SupportedLanguageDTO = SupportedLanguageDTO.DEFAULT,
+)

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentBusinessHandler.kt
@@ -4,10 +4,8 @@ import arrow.core.Either
 import no.elhub.auth.features.businessprocesses.BusinessProcessError
 import no.elhub.auth.features.businessprocesses.changeofbalancesupplier.ChangeOfBalanceSupplierBusinessHandler
 import no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplier.MoveInAndChangeOfBalanceSupplierBusinessHandler
-import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.create.command.DocumentCommand
-import no.elhub.auth.features.documents.create.dto.SupportedLanguageDTO
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 
 class ProxyDocumentBusinessHandler(
@@ -35,22 +33,3 @@ interface DocumentBusinessHandler {
 
     fun getCreateGrantProperties(document: AuthorizationDocument): CreateGrantProperties
 }
-
-data class CreateDocumentBusinessModel(
-    val authorizedParty: AuthorizationParty,
-    val documentType: AuthorizationDocument.Type,
-    val requestedBy: AuthorizationParty,
-    val requestedFrom: AuthorizationParty,
-    val requestedTo: AuthorizationParty,
-    val meta: CreateDocumentBusinessMeta,
-)
-
-data class CreateDocumentBusinessMeta(
-    val requestedFromName: String,
-    val requestedForMeteringPointId: String,
-    val requestedForMeteringPointAddress: String,
-    val balanceSupplierName: String,
-    val balanceSupplierContractName: String,
-    val moveInDate: kotlinx.datetime.LocalDate? = null,
-    val language: SupportedLanguageDTO = SupportedLanguageDTO.DEFAULT,
-)

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentBusinessHandler.kt
@@ -4,16 +4,17 @@ import arrow.core.Either
 import no.elhub.auth.features.businessprocesses.BusinessProcessError
 import no.elhub.auth.features.businessprocesses.changeofbalancesupplier.ChangeOfBalanceSupplierBusinessHandler
 import no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplier.MoveInAndChangeOfBalanceSupplierBusinessHandler
+import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.create.command.DocumentCommand
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
+import no.elhub.auth.features.documents.create.dto.SupportedLanguageDTO
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 
 class ProxyDocumentBusinessHandler(
     private val changeOfBalanceSupplierHandler: ChangeOfBalanceSupplierBusinessHandler,
     private val moveInAndChangeOfBalanceSupplierHandler: MoveInAndChangeOfBalanceSupplierBusinessHandler,
 ) : DocumentBusinessHandler {
-    override suspend fun validateAndReturnDocumentCommand(model: CreateDocumentModel): Either<BusinessProcessError, DocumentCommand> =
+    override suspend fun validateAndReturnDocumentCommand(model: CreateDocumentBusinessModel): Either<BusinessProcessError, DocumentCommand> =
         when (model.documentType) {
             AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson -> changeOfBalanceSupplierHandler.validateAndReturnDocumentCommand(model)
 
@@ -30,7 +31,26 @@ class ProxyDocumentBusinessHandler(
 }
 
 interface DocumentBusinessHandler {
-    suspend fun validateAndReturnDocumentCommand(model: CreateDocumentModel): Either<BusinessProcessError, DocumentCommand>
+    suspend fun validateAndReturnDocumentCommand(model: CreateDocumentBusinessModel): Either<BusinessProcessError, DocumentCommand>
 
     fun getCreateGrantProperties(document: AuthorizationDocument): CreateGrantProperties
 }
+
+data class CreateDocumentBusinessModel(
+    val authorizedParty: AuthorizationParty,
+    val documentType: AuthorizationDocument.Type,
+    val requestedBy: AuthorizationParty,
+    val requestedFrom: AuthorizationParty,
+    val requestedTo: AuthorizationParty,
+    val meta: CreateDocumentBusinessMeta,
+)
+
+data class CreateDocumentBusinessMeta(
+    val requestedFromName: String,
+    val requestedForMeteringPointId: String,
+    val requestedForMeteringPointAddress: String,
+    val balanceSupplierName: String,
+    val balanceSupplierContractName: String,
+    val moveInDate: kotlinx.datetime.LocalDate? = null,
+    val language: SupportedLanguageDTO = SupportedLanguageDTO.DEFAULT,
+)

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/Handler.kt
@@ -7,6 +7,7 @@ import no.elhub.auth.features.common.party.PartyError
 import no.elhub.auth.features.common.party.PartyService
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.common.AuthorizationDocumentProperty
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.common.DocumentBusinessHandler
 import no.elhub.auth.features.documents.common.DocumentRepository
 import no.elhub.auth.features.documents.common.SignatureService
@@ -25,9 +26,10 @@ class Handler(
     suspend operator fun invoke(model: CreateDocumentModel): Either<CreateError, AuthorizationDocument> =
         either {
             logger.info("event=authorization_document_creation type=${model.documentType}")
+
             val requestedByParty =
                 partyService
-                    .resolve(model.meta.requestedBy)
+                    .resolve(model.coreMeta.requestedBy)
                     .mapLeft { error ->
                         when (error) {
                             PartyError.InvalidNin -> CreateError.InvalidNinError
@@ -42,7 +44,7 @@ class Handler(
 
             val requestedFromParty =
                 partyService
-                    .resolve(model.meta.requestedFrom)
+                    .resolve(model.coreMeta.requestedFrom)
                     .mapLeft { error ->
                         when (error) {
                             PartyError.InvalidNin -> CreateError.InvalidNinError
@@ -53,7 +55,7 @@ class Handler(
 
             val requestedToParty =
                 partyService
-                    .resolve(model.meta.requestedTo)
+                    .resolve(model.coreMeta.requestedTo)
                     .mapLeft { error ->
                         when (error) {
                             PartyError.InvalidNin -> CreateError.InvalidNinError
@@ -62,9 +64,18 @@ class Handler(
                     }
                     .bind()
 
+            val businessModel = CreateDocumentBusinessModel(
+                authorizedParty = model.authorizedParty,
+                documentType = model.documentType,
+                requestedBy = requestedByParty,
+                requestedFrom = requestedFromParty,
+                requestedTo = requestedToParty,
+                meta = model.businessMeta
+            )
+
             val command =
                 businessHandler
-                    .validateAndReturnDocumentCommand(model)
+                    .validateAndReturnDocumentCommand(businessModel)
                     .mapLeft { err ->
                         logger.info("event=authorization_document_business_validation_error kind=${err.kind} detail=${err.detail}")
                         CreateError.BusinessError(err)

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/command/DocumentCommand.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/command/DocumentCommand.kt
@@ -1,7 +1,6 @@
 package no.elhub.auth.features.documents.create.command
 
 import no.elhub.auth.features.common.CreateScopeData
-import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.documents.AuthorizationDocument
 import java.time.OffsetDateTime
 
@@ -11,9 +10,6 @@ interface DocumentMetaMarker {
 
 data class DocumentCommand(
     val type: AuthorizationDocument.Type,
-    val requestedFrom: PartyIdentifier,
-    val requestedTo: PartyIdentifier,
-    val requestedBy: PartyIdentifier,
     val validTo: OffsetDateTime,
     val scopes: List<CreateScopeData>,
     val meta: DocumentMetaMarker,

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/dto/JsonApiCreateRequest.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/dto/JsonApiCreateRequest.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessMeta
+import no.elhub.auth.features.documents.create.model.CreateDocumentCoreMeta
 import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.devxp.jsonapi.model.JsonApiAttributes
 import no.elhub.devxp.jsonapi.model.JsonApiResourceMeta
@@ -35,5 +37,18 @@ fun JsonApiCreateDocumentRequest.toModel(authorizedParty: AuthorizationParty): C
     CreateDocumentModel(
         authorizedParty = authorizedParty,
         documentType = this.data.attributes.documentType,
-        meta = this.data.meta,
+        coreMeta = CreateDocumentCoreMeta(
+            requestedBy = this.data.meta.requestedBy,
+            requestedTo = this.data.meta.requestedTo,
+            requestedFrom = this.data.meta.requestedFrom
+        ),
+        businessMeta = CreateDocumentBusinessMeta(
+            requestedFromName = this.data.meta.requestedFromName,
+            requestedForMeteringPointId = this.data.meta.requestedForMeteringPointId,
+            requestedForMeteringPointAddress = this.data.meta.requestedForMeteringPointAddress,
+            balanceSupplierName = this.data.meta.balanceSupplierName,
+            balanceSupplierContractName = this.data.meta.balanceSupplierContractName,
+            moveInDate = this.data.meta.moveInDate,
+            language = this.data.meta.language,
+        ),
     )

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/model/CreateDocumentModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/model/CreateDocumentModel.kt
@@ -1,11 +1,19 @@
 package no.elhub.auth.features.documents.create.model
 
 import no.elhub.auth.features.common.party.AuthorizationParty
+import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.documents.AuthorizationDocument
-import no.elhub.auth.features.documents.create.dto.CreateDocumentMeta
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessMeta
 
 data class CreateDocumentModel(
     val authorizedParty: AuthorizationParty,
     val documentType: AuthorizationDocument.Type,
-    val meta: CreateDocumentMeta,
+    val coreMeta: CreateDocumentCoreMeta,
+    val businessMeta: CreateDocumentBusinessMeta,
+)
+
+data class CreateDocumentCoreMeta(
+    val requestedBy: PartyIdentifier,
+    val requestedFrom: PartyIdentifier,
+    val requestedTo: PartyIdentifier,
 )

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/CreateRequestBusinessModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/CreateRequestBusinessModel.kt
@@ -1,0 +1,24 @@
+package no.elhub.auth.features.requests.common
+
+import kotlinx.datetime.LocalDate
+import no.elhub.auth.features.common.party.AuthorizationParty
+import no.elhub.auth.features.requests.AuthorizationRequest
+
+data class CreateRequestBusinessModel(
+    val authorizedParty: AuthorizationParty,
+    val requestType: AuthorizationRequest.Type,
+    val requestedBy: AuthorizationParty,
+    val requestedFrom: AuthorizationParty,
+    val requestedTo: AuthorizationParty,
+    val meta: CreateRequestBusinessMeta,
+)
+
+data class CreateRequestBusinessMeta(
+    val requestedFromName: String,
+    val requestedForMeteringPointId: String,
+    val requestedForMeteringPointAddress: String,
+    val balanceSupplierName: String,
+    val balanceSupplierContractName: String,
+    val moveInDate: LocalDate? = null,
+    val redirectURI: String? = null,
+)

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/ProxyRequestBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/ProxyRequestBusinessHandler.kt
@@ -1,11 +1,9 @@
 package no.elhub.auth.features.requests.common
 
 import arrow.core.Either
-import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.businessprocesses.BusinessProcessError
 import no.elhub.auth.features.businessprocesses.changeofbalancesupplier.ChangeOfBalanceSupplierBusinessHandler
 import no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplier.MoveInAndChangeOfBalanceSupplierBusinessHandler
-import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.create.command.RequestCommand
@@ -34,22 +32,3 @@ interface RequestBusinessHandler {
     suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestBusinessModel): Either<BusinessProcessError, RequestCommand>
     fun getCreateGrantProperties(request: AuthorizationRequest): CreateGrantProperties
 }
-
-data class CreateRequestBusinessModel(
-    val authorizedParty: AuthorizationParty,
-    val requestType: AuthorizationRequest.Type,
-    val requestedBy: AuthorizationParty,
-    val requestedFrom: AuthorizationParty,
-    val requestedTo: AuthorizationParty,
-    val meta: CreateRequestBusinessMeta,
-)
-
-data class CreateRequestBusinessMeta(
-    val requestedFromName: String,
-    val requestedForMeteringPointId: String,
-    val requestedForMeteringPointAddress: String,
-    val balanceSupplierName: String,
-    val balanceSupplierContractName: String,
-    val moveInDate: LocalDate? = null,
-    val redirectURI: String? = null,
-)

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/ProxyRequestBusinessHandler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/ProxyRequestBusinessHandler.kt
@@ -1,20 +1,20 @@
 package no.elhub.auth.features.requests.common
 
 import arrow.core.Either
+import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.businessprocesses.BusinessProcessError
 import no.elhub.auth.features.businessprocesses.changeofbalancesupplier.ChangeOfBalanceSupplierBusinessHandler
 import no.elhub.auth.features.businessprocesses.moveinandchangeofbalancesupplier.MoveInAndChangeOfBalanceSupplierBusinessHandler
+import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
 import no.elhub.auth.features.requests.create.command.RequestCommand
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
 
 class ProxyRequestBusinessHandler(
     private val changeOfBalanceSupplierHandler: ChangeOfBalanceSupplierBusinessHandler,
     private val moveInAndChangeOfBalanceSupplierHandler: MoveInAndChangeOfBalanceSupplierBusinessHandler,
 ) : RequestBusinessHandler {
-    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestModel): Either<BusinessProcessError, RequestCommand> =
+    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestBusinessModel): Either<BusinessProcessError, RequestCommand> =
         when (createRequestModel.requestType) {
             AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson -> changeOfBalanceSupplierHandler.validateAndReturnRequestCommand(createRequestModel)
 
@@ -29,3 +29,27 @@ class ProxyRequestBusinessHandler(
             AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson -> moveInAndChangeOfBalanceSupplierHandler.getCreateGrantProperties(request)
         }
 }
+
+interface RequestBusinessHandler {
+    suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestBusinessModel): Either<BusinessProcessError, RequestCommand>
+    fun getCreateGrantProperties(request: AuthorizationRequest): CreateGrantProperties
+}
+
+data class CreateRequestBusinessModel(
+    val authorizedParty: AuthorizationParty,
+    val requestType: AuthorizationRequest.Type,
+    val requestedBy: AuthorizationParty,
+    val requestedFrom: AuthorizationParty,
+    val requestedTo: AuthorizationParty,
+    val meta: CreateRequestBusinessMeta,
+)
+
+data class CreateRequestBusinessMeta(
+    val requestedFromName: String,
+    val requestedForMeteringPointId: String,
+    val requestedForMeteringPointAddress: String,
+    val balanceSupplierName: String,
+    val balanceSupplierContractName: String,
+    val moveInDate: LocalDate? = null,
+    val redirectURI: String? = null,
+)

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/Handler.kt
@@ -3,14 +3,13 @@ package no.elhub.auth.features.requests.create
 import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
-import no.elhub.auth.features.businessprocesses.BusinessProcessError
 import no.elhub.auth.features.common.party.PartyError
 import no.elhub.auth.features.common.party.PartyService
-import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AuthorizationRequestProperty
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.common.RequestRepository
-import no.elhub.auth.features.requests.create.command.RequestCommand
 import no.elhub.auth.features.requests.create.model.CreateRequestModel
 import org.slf4j.LoggerFactory
 
@@ -25,7 +24,7 @@ class Handler(
         logger.info("event=authorization_request_creation type=${model.requestType}")
         val requestedByParty =
             partyService
-                .resolve(model.meta.requestedBy)
+                .resolve(model.coreMeta.requestedBy)
                 .mapLeft { error ->
                     when (error) {
                         PartyError.InvalidNin -> CreateError.InvalidNinError
@@ -40,7 +39,7 @@ class Handler(
 
         val requestedFromParty =
             partyService
-                .resolve(model.meta.requestedFrom)
+                .resolve(model.coreMeta.requestedFrom)
                 .mapLeft { error ->
                     when (error) {
                         PartyError.InvalidNin -> CreateError.InvalidNinError
@@ -51,7 +50,7 @@ class Handler(
 
         val requestedToParty =
             partyService
-                .resolve(model.meta.requestedTo)
+                .resolve(model.coreMeta.requestedTo)
                 .mapLeft { error ->
                     when (error) {
                         PartyError.InvalidNin -> CreateError.InvalidNinError
@@ -60,9 +59,18 @@ class Handler(
                 }
                 .bind()
 
+        val businessModel = CreateRequestBusinessModel(
+            authorizedParty = model.authorizedParty,
+            requestType = model.requestType,
+            requestedBy = requestedByParty,
+            requestedFrom = requestedFromParty,
+            requestedTo = requestedToParty,
+            meta = model.businessMeta
+        )
+
         val businessCommand =
             businessHandler
-                .validateAndReturnRequestCommand(model)
+                .validateAndReturnRequestCommand(businessModel)
                 .mapLeft { err ->
                     logger.info("event=authorization_request_business_validation_error kind=${err.kind} detail=${err.detail}")
                     CreateError.BusinessError(err)
@@ -97,9 +105,4 @@ class Handler(
 
         savedRequest
     }
-}
-
-interface RequestBusinessHandler {
-    suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestModel): Either<BusinessProcessError, RequestCommand>
-    fun getCreateGrantProperties(request: AuthorizationRequest): CreateGrantProperties
 }

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/command/RequestCommand.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/command/RequestCommand.kt
@@ -1,7 +1,6 @@
 package no.elhub.auth.features.requests.create.command
 
 import no.elhub.auth.features.common.CreateScopeData
-import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.requests.AuthorizationRequest
 import java.time.OffsetDateTime
 
@@ -16,9 +15,6 @@ fun Map<String, String>.withTextVersion(version: String): Map<String, String> =
 
 data class RequestCommand(
     val type: AuthorizationRequest.Type,
-    val requestedFrom: PartyIdentifier,
-    val requestedBy: PartyIdentifier,
-    val requestedTo: PartyIdentifier,
     val validTo: OffsetDateTime,
     val scopes: List<CreateScopeData>,
     val meta: RequestMetaMarker,

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/dto/JsonApiCreateRequest.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/dto/JsonApiCreateRequest.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.Serializable
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.requests.AuthorizationRequest
+import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
+import no.elhub.auth.features.requests.create.model.CreateRequestCoreMeta
 import no.elhub.auth.features.requests.create.model.CreateRequestModel
 import no.elhub.devxp.jsonapi.model.JsonApiAttributes
 import no.elhub.devxp.jsonapi.model.JsonApiResourceMeta
@@ -35,19 +37,18 @@ fun JsonApiCreateRequest.toModel(authorizedParty: AuthorizationParty): CreateReq
     CreateRequestModel(
         authorizedParty = authorizedParty,
         requestType = this.data.attributes.requestType,
-        meta = this.data.meta.toModel()
-    )
-
-fun CreateRequestMeta.toModel(): no.elhub.auth.features.requests.create.model.CreateRequestMeta =
-    no.elhub.auth.features.requests.create.model.CreateRequestMeta(
-        requestedBy = this.requestedBy,
-        requestedFrom = this.requestedFrom,
-        requestedFromName = this.requestedFromName,
-        requestedTo = this.requestedTo,
-        requestedForMeteringPointId = this.requestedForMeteringPointId,
-        requestedForMeteringPointAddress = this.requestedForMeteringPointAddress,
-        balanceSupplierName = this.balanceSupplierName,
-        balanceSupplierContractName = this.balanceSupplierContractName,
-        moveInDate = this.moveInDate,
-        redirectURI = this.redirectURI,
+        coreMeta = CreateRequestCoreMeta(
+            requestedBy = this.data.meta.requestedBy,
+            requestedFrom = this.data.meta.requestedFrom,
+            requestedTo = this.data.meta.requestedTo,
+        ),
+        businessMeta = CreateRequestBusinessMeta(
+            requestedFromName = this.data.meta.requestedFromName,
+            requestedForMeteringPointId = this.data.meta.requestedForMeteringPointId,
+            requestedForMeteringPointAddress = this.data.meta.requestedForMeteringPointAddress,
+            balanceSupplierName = this.data.meta.balanceSupplierName,
+            balanceSupplierContractName = this.data.meta.balanceSupplierContractName,
+            moveInDate = this.data.meta.moveInDate,
+            redirectURI = this.data.meta.redirectURI,
+        ),
     )

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/model/CreateRequestModel.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/model/CreateRequestModel.kt
@@ -1,25 +1,19 @@
 package no.elhub.auth.features.requests.create.model
 
-import kotlinx.datetime.LocalDate
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.requests.AuthorizationRequest
+import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
 
 data class CreateRequestModel(
     val authorizedParty: AuthorizationParty,
     val requestType: AuthorizationRequest.Type,
-    val meta: CreateRequestMeta,
+    val coreMeta: CreateRequestCoreMeta,
+    val businessMeta: CreateRequestBusinessMeta,
 )
 
-data class CreateRequestMeta(
+data class CreateRequestCoreMeta(
     val requestedBy: PartyIdentifier,
     val requestedFrom: PartyIdentifier,
-    val requestedFromName: String,
     val requestedTo: PartyIdentifier,
-    val requestedForMeteringPointId: String,
-    val requestedForMeteringPointAddress: String,
-    val balanceSupplierName: String,
-    val balanceSupplierContractName: String,
-    val moveInDate: LocalDate? = null,
-    val redirectURI: String? = null,
 )

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
@@ -8,8 +8,8 @@ import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.common.AuthorizationGrantProperty
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AcceptWithGrantError
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.common.RequestRepository
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
 import org.slf4j.LoggerFactory
 
 class Handler(

--- a/src/test/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/ChangeOfBalanceSupplierBusinessHandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/ChangeOfBalanceSupplierBusinessHandlerTest.kt
@@ -44,33 +44,29 @@ import no.elhub.auth.features.businessprocesses.structuredata.organisations.Orga
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.OrganisationsServiceTestData.VALID_PARTY_ID
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.organisationsServiceHttpClient
 import no.elhub.auth.features.common.party.AuthorizationParty
-import no.elhub.auth.features.common.party.PartyIdentifier
-import no.elhub.auth.features.common.party.PartyIdentifierType
 import no.elhub.auth.features.common.party.PartyType.Organization
-import no.elhub.auth.features.common.person.Person
-import no.elhub.auth.features.common.person.PersonService
+import no.elhub.auth.features.common.party.PartyType.Person
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.documents.AuthorizationDocument
-import no.elhub.auth.features.documents.create.dto.CreateDocumentMeta
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessMeta
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.filegenerator.SupportedLanguage
 import no.elhub.auth.features.requests.AuthorizationRequest
+import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 import no.elhub.auth.features.requests.create.command.TEXT_VERSION_KEY
-import no.elhub.auth.features.requests.create.model.CreateRequestMeta
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObject
-import java.util.UUID
 
-private val VALID_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, VALID_PARTY_ID)
-private val AUTHORIZED_PARTY = AuthorizationParty(id = VALID_PARTY_ID, type = Organization)
-private val NOT_VALID_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, "0000")
-private val NON_EXISTING_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, NOT_BALANCE_SUPPLIER_PARTY_ID)
-private val INACTIVE_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, INACTIVE_PARTY_ID)
-private val MATCHING_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, CURRENT_PARTY_ID)
-private val END_USER = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "123456789")
-private val ANOTHER_END_USER = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "987654321")
-private val SHARED_END_USER = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "11223344556")
+private val VALID_PARTY = AuthorizationParty(id = VALID_PARTY_ID, type = Organization)
+private val AUTHORIZED_PARTY = VALID_PARTY
+private val NOT_VALID_PARTY = AuthorizationParty(id = "0000", type = Organization)
+private val NON_EXISTING_PARTY = AuthorizationParty(id = NOT_BALANCE_SUPPLIER_PARTY_ID, type = Organization)
+private val INACTIVE_PARTY = AuthorizationParty(id = INACTIVE_PARTY_ID, type = Organization)
+private val MATCHING_PARTY = AuthorizationParty(id = CURRENT_PARTY_ID, type = Organization)
+private val END_USER = AuthorizationParty(id = END_USER_ID_1, type = Person)
+private val ANOTHER_END_USER = AuthorizationParty(id = END_USER_ID_2, type = Person)
+private val SHARED_END_USER = AuthorizationParty(id = SHARED_END_USER_ID_1, type = Person)
 
 class ChangeOfBalanceSupplierBusinessHandlerTest :
     FunSpec({
@@ -80,7 +76,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
         lateinit var handler: ChangeOfBalanceSupplierBusinessHandler
         lateinit var organisationsService: OrganisationsService
 
-        val personService = mockk<PersonService>()
         val stromprisService = mockk<StromprisService>()
         val edielService = mockk<EdielService>()
         val jwtTokenProvider = mockk<JwtTokenProvider>()
@@ -106,7 +101,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             )
             handler = ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 organisationsService = organisationsService,
                 stromprisService = stromprisService,
                 edielService = edielService,
@@ -116,48 +110,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             )
         }
 
-        coEvery { personService.findOrCreateByNin(END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    END_USER_ID_1
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(ANOTHER_END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    END_USER_ID_2
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(SHARED_END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    SHARED_END_USER_ID_1
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    END_USER_ID_1
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(ANOTHER_END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    END_USER_ID_2
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(SHARED_END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    SHARED_END_USER_ID_1
-                )
-            )
-        )
         beforeTest {
             clearMocks(edielService, answers = false, recordedCalls = true)
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(
@@ -171,15 +123,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on missing requestedFromName") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -194,15 +146,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails when requestedFrom is not related to metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -217,15 +169,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails when requestedFrom has access to metering point but is not end user") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = SHARED_END_USER,
+                    requestedTo = SHARED_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = SHARED_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = SHARED_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -240,15 +192,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on invalid metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = "123",
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -263,15 +215,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on unexisting metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = NON_EXISTING_METERING_POINT,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -286,15 +238,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on metering point blocked for switching") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = BLOCKED_FOR_SWITCHING_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -309,15 +261,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on not valid redirect URI") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -332,15 +284,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation allows missing redirect URI and skips Ediel lookup") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -355,15 +307,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on blank redirect URI") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -386,15 +338,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
                 )
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -410,7 +362,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
         test("request validation in test environment uses test URL from Ediel") {
             val handlerWithTestEnvironment = ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 organisationsService = organisationsService,
                 stromprisService = stromprisService,
                 edielService = edielService,
@@ -427,15 +378,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
                 )
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -451,7 +402,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             val mockEdielService = mockk<EdielService>()
             val handlerWithRedirectValidationDisabled = ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 organisationsService = organisationsService,
                 stromprisService = stromprisService,
                 edielService = mockEdielService,
@@ -460,15 +410,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
                 validateBalanceSupplierContractName = false
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -483,15 +433,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on not valid requested by") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = NOT_VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = NOT_VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -506,15 +456,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on non existing requested by") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = NON_EXISTING_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = NON_EXISTING_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -529,15 +479,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on not active requested by") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = INACTIVE_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = INACTIVE_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -552,15 +502,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on requested to not matching requested from") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -583,7 +533,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             } returns Either.Left(ClientError.BadRequest)
             val handlerWithMockedService = ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = mockMeteringPointsService,
-                personService = personService,
                 organisationsService = organisationsService,
                 stromprisService = stromprisService,
                 edielService = edielService,
@@ -593,15 +542,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             )
 
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -624,7 +573,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             } returns Either.Left(ClientError.ServerError)
             val handlerWithMockedService = ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 organisationsService = mockOrganisationsService,
                 stromprisService = stromprisService,
                 edielService = edielService,
@@ -634,15 +582,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             )
 
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -657,15 +605,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("strompris service is not called if validateBalanceSupplierContractName is false, assuming all previous validations pass") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -698,7 +646,6 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
             )
             val handlerWithMockedStromprisService = ChangeOfBalanceSupplierBusinessHandler(
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 organisationsService = organisationsService,
                 stromprisService = mockStromprisService,
                 edielService = edielService,
@@ -707,15 +654,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
                 validateBalanceSupplierContractName = true
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -729,15 +676,15 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request produces RequestCommand for valid input") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -773,14 +720,14 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("document produces DocumentCommand for valid input") {
             val model =
-                CreateDocumentModel(
-                    authorizedParty = AuthorizationParty(id = VALID_PARTY.idValue, type = Organization),
+                CreateDocumentBusinessModel(
+                    authorizedParty = VALID_PARTY,
                     documentType = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateDocumentMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
-                        requestedTo = END_USER,
+                    CreateDocumentBusinessMeta(
                         requestedFromName = "From",
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",

--- a/src/test/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/MoveInAndChangeOfBalanceSupplierBusinessHandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/MoveInAndChangeOfBalanceSupplierBusinessHandlerTest.kt
@@ -44,34 +44,30 @@ import no.elhub.auth.features.businessprocesses.structuredata.organisations.Orga
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.OrganisationsServiceTestData.VALID_PARTY_ID
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.organisationsServiceHttpClient
 import no.elhub.auth.features.common.party.AuthorizationParty
-import no.elhub.auth.features.common.party.PartyIdentifier
-import no.elhub.auth.features.common.party.PartyIdentifierType
 import no.elhub.auth.features.common.party.PartyType
-import no.elhub.auth.features.common.person.Person
-import no.elhub.auth.features.common.person.PersonService
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.documents.AuthorizationDocument
-import no.elhub.auth.features.documents.create.dto.CreateDocumentMeta
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessMeta
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.filegenerator.SupportedLanguage
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AuthorizationRequestProperty
+import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 import no.elhub.auth.features.requests.create.command.TEXT_VERSION_KEY
-import no.elhub.auth.features.requests.create.model.CreateRequestMeta
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObject
 import java.util.UUID
 
-private val VALID_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, VALID_PARTY_ID)
-private val NOT_VALID_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, "0000")
-private val NON_EXISTING_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, NOT_BALANCE_SUPPLIER_PARTY_ID)
-private val INACTIVE_PARTY = PartyIdentifier(PartyIdentifierType.OrganizationNumber, INACTIVE_PARTY_ID)
-private val AUTHORIZED_PARTY = AuthorizationParty(id = VALID_PARTY_ID, type = PartyType.Organization)
+private val VALID_PARTY = AuthorizationParty(id = VALID_PARTY_ID, type = PartyType.Organization)
+private val NOT_VALID_PARTY = AuthorizationParty(id = "0000", type = PartyType.Organization)
+private val NON_EXISTING_PARTY = AuthorizationParty(id = NOT_BALANCE_SUPPLIER_PARTY_ID, type = PartyType.Organization)
+private val INACTIVE_PARTY = AuthorizationParty(id = INACTIVE_PARTY_ID, type = PartyType.Organization)
+private val AUTHORIZED_PARTY = VALID_PARTY
 private val VALID_MOVEIN_DATE = LocalDate(2025, 1, 1)
-private val END_USER = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "123456789")
-private val ANOTHER_END_USER = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "987654321")
-private val SHARED_END_USER = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "11223344556")
+private val END_USER = AuthorizationParty(id = END_USER_ID_1, type = PartyType.Person)
+private val ANOTHER_END_USER = AuthorizationParty(id = END_USER_ID_2, type = PartyType.Person)
+private val SHARED_END_USER = AuthorizationParty(id = SHARED_END_USER_ID_1, type = PartyType.Person)
 
 class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
     FunSpec({
@@ -81,7 +77,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
         lateinit var meteringPointsService: MeteringPointsService
         lateinit var handler: MoveInAndChangeOfBalanceSupplierBusinessHandler
 
-        val personService = mockk<PersonService>()
         val stromprisService = mockk<StromprisService>()
         val edielService = mockk<EdielService>()
         val jwtTokenProvider = mockk<JwtTokenProvider>()
@@ -105,7 +100,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             handler = MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 organisationsService = organisationsService,
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 stromprisService = stromprisService,
                 edielService = edielService,
                 edielEnvironment = EdielEnvironment.PRODUCTION,
@@ -114,27 +108,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             )
         }
 
-        coEvery { personService.findOrCreateByNin(END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    END_USER_ID_1
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(ANOTHER_END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    END_USER_ID_2
-                )
-            )
-        )
-        coEvery { personService.findOrCreateByNin(SHARED_END_USER.idValue) } returns Either.Right(
-            Person(
-                UUID.fromString(
-                    SHARED_END_USER_ID_1
-                )
-            )
-        )
         beforeTest {
             clearMocks(edielService, answers = false, recordedCalls = true)
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(
@@ -148,15 +121,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation allows missing moveInDate") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -173,15 +146,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on future moveInDate") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -197,15 +170,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation allows moveInDate today") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -220,15 +193,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on not valid redirect URI") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -244,15 +217,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation allows missing redirect URI and skips Ediel lookup") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -268,15 +241,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on blank redirect URI") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -294,15 +267,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
         test("request validation allows redirect URI when host matches Ediel domain") {
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(edielRedirectResponse("https://example.com/login"))
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -319,7 +292,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             val handlerWithTestEnvironment = MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 organisationsService = organisationsService,
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 stromprisService = stromprisService,
                 edielService = edielService,
                 edielEnvironment = EdielEnvironment.TEST,
@@ -333,15 +305,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
                 )
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -359,7 +331,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             val handlerWithRedirectValidationDisabled = MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 organisationsService = organisationsService,
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 stromprisService = stromprisService,
                 edielService = mockEdielService,
                 edielEnvironment = EdielEnvironment.PRODUCTION,
@@ -367,15 +338,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
                 validateBalanceSupplierContractName = false
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -392,15 +363,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
         test("request validation allows redirect URI when host is subdomain of Ediel domain") {
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(edielRedirectResponse("https://example.com/login"))
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -416,15 +387,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
         test("request validation fails when redirect URI domain does not match Ediel domain") {
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(edielRedirectResponse("https://other-domain.example/callback"))
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -440,15 +411,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on invalid metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = "123",
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -464,15 +435,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on non existing metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = NON_EXISTING_METERING_POINT,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -488,15 +459,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on requestedFrom being owner of metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = END_USER,
+                    requestedTo = END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -512,15 +483,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation allows on requestedFrom having access to metering point") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = SHARED_END_USER,
+                    requestedTo = SHARED_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = SHARED_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = SHARED_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -535,15 +506,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on not valid requested by") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = NOT_VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = NOT_VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -559,15 +530,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on non existing requested by") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = NON_EXISTING_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = NON_EXISTING_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -583,15 +554,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on non Active requested by") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = INACTIVE_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = INACTIVE_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -616,7 +587,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             val handlerWithMockedService = MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 organisationsService = organisationsService,
                 meteringPointsService = mockMeteringPointsService,
-                personService = personService,
                 stromprisService = stromprisService,
                 edielService = edielService,
                 edielEnvironment = EdielEnvironment.PRODUCTION,
@@ -625,15 +595,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             )
 
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -658,7 +628,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             val handlerWithMockedService = MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 organisationsService = mockOrganisationsService,
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 stromprisService = stromprisService,
                 edielService = edielService,
                 edielEnvironment = EdielEnvironment.PRODUCTION,
@@ -667,15 +636,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             )
 
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -691,15 +660,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request validation fails on requested to not matching requested from") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = SHARED_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = SHARED_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -715,15 +684,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("strompris service is not called if validateBalanceSupplierContractName is false, assuming all previous validations pass") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -758,7 +727,6 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
             val handlerWithMockedStromprisService = MoveInAndChangeOfBalanceSupplierBusinessHandler(
                 organisationsService = organisationsService,
                 meteringPointsService = meteringPointsService,
-                personService = personService,
                 stromprisService = mockStromprisService,
                 edielService = edielService,
                 edielEnvironment = EdielEnvironment.PRODUCTION,
@@ -766,15 +734,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
                 validateBalanceSupplierContractName = true
             )
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -790,15 +758,15 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("request produces RequestCommand for valid input") {
             val model =
-                CreateRequestModel(
+                CreateRequestBusinessModel(
                     authorizedParty = AUTHORIZED_PARTY,
                     requestType = AuthorizationRequest.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateRequestMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
+                    CreateRequestBusinessMeta(
                         requestedFromName = "From",
-                        requestedTo = ANOTHER_END_USER,
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",
                         balanceSupplierName = "Supplier",
@@ -845,14 +813,14 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
 
         test("document produces DocumentCommand for valid input") {
             val model =
-                CreateDocumentModel(
-                    authorizedParty = AuthorizationParty(id = VALID_PARTY.idValue, type = PartyType.Organization),
+                CreateDocumentBusinessModel(
+                    authorizedParty = VALID_PARTY,
                     documentType = AuthorizationDocument.Type.MoveInAndChangeOfBalanceSupplierForPerson,
+                    requestedBy = VALID_PARTY,
+                    requestedFrom = ANOTHER_END_USER,
+                    requestedTo = ANOTHER_END_USER,
                     meta =
-                    CreateDocumentMeta(
-                        requestedBy = VALID_PARTY,
-                        requestedFrom = ANOTHER_END_USER,
-                        requestedTo = ANOTHER_END_USER,
+                    CreateDocumentBusinessMeta(
                         requestedFromName = "From",
                         requestedForMeteringPointId = VALID_METERING_POINT_1,
                         requestedForMeteringPointAddress = "addr",

--- a/src/test/kotlin/no/elhub/auth/features/common/auth/PDPAuthorizationProviderTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/common/auth/PDPAuthorizationProviderTest.kt
@@ -328,7 +328,6 @@ class PDPAuthorizationProviderTest : FunSpec({
                         actingType = "organisation",
                         actingId = "b8af0fb3-bad7-4ca4-9153-919243635601",
                         actingOrganisationNumber = orgNumber,
-                        originalId = "e76439bc-0344-4ef5-b2f8-41a72c25ffd8"
                     )
                 )
             )
@@ -357,7 +356,6 @@ class PDPAuthorizationProviderTest : FunSpec({
                         actingId = "",
                         actingType = null,
                         error = "Unable to verify OnBehalfOfOrganisationId for end user token",
-                        originalId = "e76439bc-0344-4ef5-b2f8-41a72c25ffd8"
                     )
                 )
             )
@@ -404,7 +402,6 @@ class PDPAuthorizationProviderTest : FunSpec({
                     authInfo = AuthInfo(
                         actingType = "",
                         actingId = "",
-                        originalId = "e76439bc-0344-4ef5-b2f8-41a72c25ffd8"
                     )
                 )
             )

--- a/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
@@ -47,6 +47,7 @@ import no.elhub.auth.features.common.party.PartyIdentifier
 import no.elhub.auth.features.common.party.PartyIdentifierType
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.common.todayOslo
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.common.DocumentBusinessHandler
 import no.elhub.auth.features.documents.create.command.DocumentCommand
 import no.elhub.auth.features.documents.create.dto.CreateDocumentMeta
@@ -55,7 +56,6 @@ import no.elhub.auth.features.documents.create.dto.CreateDocumentResponse
 import no.elhub.auth.features.documents.create.dto.JsonApiCreateDocumentRequest
 import no.elhub.auth.features.documents.create.dto.SupportedLanguageDTO
 import no.elhub.auth.features.documents.create.dto.toSupportedLanguage
-import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.documents.get.dto.GetDocumentSingleResponse
 import no.elhub.auth.features.documents.query.dto.GetDocumentCollectionResponse
 import no.elhub.auth.features.grants.AuthorizationScope
@@ -848,15 +848,12 @@ private const val REQUESTED_TO_NIN = "14810797496"
 
 private class TestDocumentBusinessHandler : DocumentBusinessHandler {
     override suspend fun validateAndReturnDocumentCommand(
-        model: CreateDocumentModel
+        model: CreateDocumentBusinessModel
     ) = when (model.documentType) {
         AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson -> {
             val meta = model.meta
             DocumentCommand(
                 type = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
-                requestedFrom = meta.requestedFrom,
-                requestedTo = meta.requestedTo,
-                requestedBy = meta.requestedBy,
                 validTo = todayOslo().plus(DatePeriod(days = 30)).toTimeZoneOffsetDateTimeAtStartOfDay(),
                 scopes = listOf(
                     CreateScopeData(

--- a/src/test/kotlin/no/elhub/auth/features/documents/create/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/create/HandlerTest.kt
@@ -25,13 +25,15 @@ import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessMeta
+import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
 import no.elhub.auth.features.documents.common.DocumentBusinessHandler
 import no.elhub.auth.features.documents.common.DocumentRepository
 import no.elhub.auth.features.documents.common.SignatureService
 import no.elhub.auth.features.documents.common.SignatureSigningError
 import no.elhub.auth.features.documents.create.command.DocumentCommand
 import no.elhub.auth.features.documents.create.command.DocumentMetaMarker
-import no.elhub.auth.features.documents.create.dto.CreateDocumentMeta
+import no.elhub.auth.features.documents.create.model.CreateDocumentCoreMeta
 import no.elhub.auth.features.documents.create.model.CreateDocumentModel
 import no.elhub.auth.features.filegenerator.SupportedLanguage
 import no.elhub.auth.features.grants.AuthorizationScope
@@ -46,11 +48,15 @@ class HandlerTest : FunSpec({
     val requestedFromParty = AuthorizationParty(id = "person-1", type = PartyType.Person)
     val requestedToParty = AuthorizationParty(id = "person-2", type = PartyType.Person)
 
-    val meta =
-        CreateDocumentMeta(
+    val coreMeta =
+        CreateDocumentCoreMeta(
             requestedBy = requestedByIdentifier,
             requestedFrom = requestedFromIdentifier,
             requestedTo = requestedToIdentifier,
+        )
+
+    val businessMeta =
+        CreateDocumentBusinessMeta(
             requestedFromName = "Requested From",
             requestedForMeteringPointId = "123456789012345678",
             requestedForMeteringPointAddress = "Address",
@@ -62,7 +68,18 @@ class HandlerTest : FunSpec({
         CreateDocumentModel(
             authorizedParty = requestedByParty,
             documentType = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
-            meta = meta,
+            coreMeta = coreMeta,
+            businessMeta = businessMeta,
+        )
+
+    val businessModel =
+        CreateDocumentBusinessModel(
+            authorizedParty = requestedByParty,
+            documentType = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
+            requestedBy = requestedByParty,
+            requestedFrom = requestedFromParty,
+            requestedTo = requestedToParty,
+            meta = businessMeta,
         )
 
     val commandMeta = object : DocumentMetaMarker {
@@ -73,9 +90,6 @@ class HandlerTest : FunSpec({
     val command =
         DocumentCommand(
             type = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
-            requestedFrom = requestedFromIdentifier,
-            requestedTo = requestedToIdentifier,
-            requestedBy = requestedByIdentifier,
             validTo = todayOslo().plus(DatePeriod(days = 30)).toTimeZoneOffsetDateTimeAtStartOfDay(),
             scopes = listOf(
                 CreateScopeData(
@@ -104,7 +118,7 @@ class HandlerTest : FunSpec({
         val fileGenerator = mockk<FileGenerator>()
 
         stubPartyResolution(partyService)
-        coEvery { businessHandler.validateAndReturnDocumentCommand(model) } returns command.right()
+        coEvery { businessHandler.validateAndReturnDocumentCommand(businessModel) } returns command.right()
         every { fileGenerator.generate(commandMeta) } returns unsignedFile.right()
         coEvery { signatureService.sign(unsignedFile) } returns signedFile.right()
 
@@ -125,6 +139,7 @@ class HandlerTest : FunSpec({
 
         response.shouldBeRight(savedDocument)
         coVerify(exactly = 1) { documentRepository.insert(any(), command.scopes) }
+        coVerify(exactly = 1) { businessHandler.validateAndReturnDocumentCommand(businessModel) }
         coVerify(exactly = 1) {
             documentRepository.insert(
                 match { document ->
@@ -217,7 +232,7 @@ class HandlerTest : FunSpec({
 
         stubPartyResolution(partyService)
         coEvery {
-            businessHandler.validateAndReturnDocumentCommand(model)
+            businessHandler.validateAndReturnDocumentCommand(businessModel)
         } returns BusinessProcessError.Validation(ChangeOfBalanceSupplierValidationError.MissingRequestedFromName.message)
             .left()
 
@@ -240,7 +255,7 @@ class HandlerTest : FunSpec({
         val fileGenerator = mockk<FileGenerator>()
 
         stubPartyResolution(partyService)
-        coEvery { businessHandler.validateAndReturnDocumentCommand(model) } returns command.right()
+        coEvery { businessHandler.validateAndReturnDocumentCommand(businessModel) } returns command.right()
         every {
             fileGenerator.generate(commandMeta)
         } returns DocumentGenerationError.ContentGenerationError.left()
@@ -261,7 +276,7 @@ class HandlerTest : FunSpec({
         val fileGenerator = mockk<FileGenerator>()
 
         stubPartyResolution(partyService)
-        coEvery { businessHandler.validateAndReturnDocumentCommand(model) } returns command.right()
+        coEvery { businessHandler.validateAndReturnDocumentCommand(businessModel) } returns command.right()
         every { fileGenerator.generate(commandMeta) } returns unsignedFile.right()
         coEvery {
             signatureService.sign(unsignedFile)
@@ -283,7 +298,7 @@ class HandlerTest : FunSpec({
         val fileGenerator = mockk<FileGenerator>()
 
         stubPartyResolution(partyService)
-        coEvery { businessHandler.validateAndReturnDocumentCommand(model) } returns command.right()
+        coEvery { businessHandler.validateAndReturnDocumentCommand(businessModel) } returns command.right()
         every { fileGenerator.generate(commandMeta) } returns unsignedFile.right()
         coEvery { signatureService.sign(unsignedFile) } returns signedFile.right()
         coEvery {

--- a/src/test/kotlin/no/elhub/auth/features/requests/create/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/create/HandlerTest.kt
@@ -23,12 +23,14 @@ import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.grants.AuthorizationScope
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AuthorizationRequestProperty
+import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 import no.elhub.auth.features.requests.common.ProxyRequestBusinessHandler
 import no.elhub.auth.features.requests.common.RequestRepository
 import no.elhub.auth.features.requests.create.command.RequestCommand
 import no.elhub.auth.features.requests.create.command.RequestMetaMarker
 import no.elhub.auth.features.requests.create.command.withTextVersion
-import no.elhub.auth.features.requests.create.model.CreateRequestMeta
+import no.elhub.auth.features.requests.create.model.CreateRequestCoreMeta
 import no.elhub.auth.features.requests.create.model.CreateRequestModel
 
 class HandlerTest : FunSpec({
@@ -41,12 +43,16 @@ class HandlerTest : FunSpec({
     val requestedFromParty = AuthorizationParty(id = "person-1", type = PartyType.Person)
     val requestedToParty = AuthorizationParty(id = "person-2", type = PartyType.Person)
 
-    val meta =
-        CreateRequestMeta(
+    val coreMeta =
+        CreateRequestCoreMeta(
             requestedBy = requestedByIdentifier,
             requestedFrom = requestedFromIdentifier,
-            requestedFromName = "Requested From",
             requestedTo = requestedToIdentifier,
+        )
+
+    val businessMeta =
+        CreateRequestBusinessMeta(
+            requestedFromName = "Requested From",
             requestedForMeteringPointId = "123456789012345678",
             requestedForMeteringPointAddress = "Address",
             balanceSupplierName = "Supplier",
@@ -58,7 +64,18 @@ class HandlerTest : FunSpec({
         CreateRequestModel(
             authorizedParty = requestedByParty,
             requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-            meta = meta,
+            coreMeta = coreMeta,
+            businessMeta = businessMeta,
+        )
+
+    val businessModel =
+        CreateRequestBusinessModel(
+            authorizedParty = requestedByParty,
+            requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+            requestedBy = requestedByParty,
+            requestedFrom = requestedFromParty,
+            requestedTo = requestedToParty,
+            meta = businessMeta,
         )
 
     val commandMeta = object : RequestMetaMarker {
@@ -69,9 +86,6 @@ class HandlerTest : FunSpec({
     val command =
         RequestCommand(
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-            requestedFrom = requestedFromIdentifier,
-            requestedBy = requestedByIdentifier,
-            requestedTo = requestedToIdentifier,
             validTo = LocalDate(2025, 1, 1).toTimeZoneOffsetDateTimeAtStartOfDay(),
             scopes = listOf(
                 CreateScopeData(
@@ -95,7 +109,7 @@ class HandlerTest : FunSpec({
         val requestRepo = mockk<RequestRepository>()
 
         stubPartyResolution(partyService)
-        coEvery { businessHandler.validateAndReturnRequestCommand(model) } returns command.right()
+        coEvery { businessHandler.validateAndReturnRequestCommand(businessModel) } returns command.right()
 
         val savedRequest =
             AuthorizationRequest.create(
@@ -125,6 +139,7 @@ class HandlerTest : FunSpec({
 
         response.shouldBeRight(savedRequest.copy(properties = expectedProperties))
         coVerify(exactly = 1) { requestRepo.insert(any(), any()) }
+        coVerify(exactly = 1) { businessHandler.validateAndReturnRequestCommand(businessModel) }
     }
 
     test("returns RequestedPartyError when requestedBy cannot be resolved") {
@@ -199,7 +214,7 @@ class HandlerTest : FunSpec({
 
         stubPartyResolution(partyService)
         coEvery {
-            businessHandler.validateAndReturnRequestCommand(model)
+            businessHandler.validateAndReturnRequestCommand(businessModel)
         } returns BusinessProcessError.Validation(ChangeOfBalanceSupplierValidationError.MissingRequestedFromName.message).left()
 
         val handler = Handler(businessHandler, partyService, requestRepo)
@@ -218,7 +233,7 @@ class HandlerTest : FunSpec({
         val requestRepo = mockk<RequestRepository>()
 
         stubPartyResolution(partyService)
-        coEvery { businessHandler.validateAndReturnRequestCommand(model) } returns command.right()
+        coEvery { businessHandler.validateAndReturnRequestCommand(businessModel) } returns command.right()
         coEvery { requestRepo.insert(any(), any()) } returns RepositoryWriteError.UnexpectedError.left()
 
         val handler = Handler(businessHandler, partyService, requestRepo)

--- a/src/test/kotlin/no/elhub/auth/features/requests/create/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/create/RouteTest.kt
@@ -142,7 +142,7 @@ class RouteTest : FunSpec({
             coVerify(exactly = 1) {
                 handler.invoke(
                     withArg {
-                        it.meta.redirectURI shouldBe null
+                        it.businessMeta.redirectURI shouldBe null
                     }
                 )
             }

--- a/src/test/kotlin/no/elhub/auth/features/requests/route/Utils.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/route/Utils.kt
@@ -23,15 +23,15 @@ import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AuthorizationRequestPropertyTable
 import no.elhub.auth.features.requests.common.AuthorizationRequestTable
+import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 import no.elhub.auth.features.requests.common.DatabaseRequestStatus
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.create.command.RequestCommand
 import no.elhub.auth.features.requests.create.command.RequestMetaMarker
 import no.elhub.auth.features.requests.create.command.withTextVersion
 import no.elhub.auth.features.requests.create.dto.CreateRequestAttributes
 import no.elhub.auth.features.requests.create.dto.CreateRequestMeta
 import no.elhub.auth.features.requests.create.dto.JsonApiCreateRequest
-import no.elhub.auth.features.requests.create.model.CreateRequestModel
 import no.elhub.auth.features.requests.create.requesttypes.RequestTypeValidationError
 import no.elhub.auth.features.requests.module
 import no.elhub.auth.features.requests.update.dto.JsonApiUpdateRequest
@@ -85,7 +85,7 @@ fun Application.testRequestBusinessModule() {
 }
 
 class TestRequestBusinessHandler : RequestBusinessHandler {
-    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestModel) =
+    override suspend fun validateAndReturnRequestCommand(createRequestModel: CreateRequestBusinessModel) =
         when (createRequestModel.requestType) {
             AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson -> {
                 val meta = createRequestModel.meta
@@ -94,9 +94,6 @@ class TestRequestBusinessHandler : RequestBusinessHandler {
                 } else {
                     RequestCommand(
                         type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                        requestedFrom = meta.requestedFrom,
-                        requestedBy = meta.requestedBy,
-                        requestedTo = meta.requestedTo,
                         validTo = todayOslo().plus(DatePeriod(days = 30)).toTimeZoneOffsetDateTimeAtStartOfDay(),
                         scopes = listOf(
                             CreateScopeData(

--- a/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
@@ -18,8 +18,8 @@ import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
+import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.common.RequestRepository
-import no.elhub.auth.features.requests.create.RequestBusinessHandler
 import java.time.OffsetDateTime
 import java.util.UUID
 


### PR DESCRIPTION
Core: split create input into core party identifiers and business meta, resolving requestedBy/requestedFrom/requestedTo before validation.
Business: validate using AuthorizationParty directly and remove party identifier/person lookup handling from business processes.
