### PR TITLE
Remove N+1 query problem from grant and request repos

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -149,7 +149,7 @@ class ExposedDocumentRepository(
                 .select(listOf(SignatoriesTable.signedBy))
                 .where {
                     (SignatoriesTable.authorizationDocumentId eq id) and
-                        (SignatoriesTable.requestedFrom eq documentRow[AuthorizationDocumentTable.requestedFrom])
+                            (SignatoriesTable.requestedFrom eq documentRow[AuthorizationDocumentTable.requestedFrom])
                 }
                 .singleOrNull()
                 ?.let { resolveParty(it[SignatoriesTable.signedBy]).bind() }

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -149,7 +149,7 @@ class ExposedDocumentRepository(
                 .select(listOf(SignatoriesTable.signedBy))
                 .where {
                     (SignatoriesTable.authorizationDocumentId eq id) and
-                            (SignatoriesTable.requestedFrom eq documentRow[AuthorizationDocumentTable.requestedFrom])
+                        (SignatoriesTable.requestedFrom eq documentRow[AuthorizationDocumentTable.requestedFrom])
                 }
                 .singleOrNull()
                 ?.let { resolveParty(it[SignatoriesTable.signedBy]).bind() }

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantPropertiesRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantPropertiesRepository.kt
@@ -58,7 +58,7 @@ object AuthorizationGrantPropertyTable : Table("auth.authorization_grant_propert
     val value = text("value")
 }
 
-private fun ResultRow.toAuthorizationGrantProperty() = AuthorizationGrantProperty(
+internal fun ResultRow.toAuthorizationGrantProperty() = AuthorizationGrantProperty(
     grantId = this[AuthorizationGrantPropertyTable.grantId],
     key = this[AuthorizationGrantPropertyTable.key],
     value = this[AuthorizationGrantPropertyTable.value]

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -12,6 +12,7 @@ import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyRecord
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
 import no.elhub.auth.features.common.party.PartyRepository
+import no.elhub.auth.features.common.party.toAuthorizationParty
 import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.AuthorizationGrant.SourceType
 import no.elhub.auth.features.grants.AuthorizationGrant.Status
@@ -22,6 +23,7 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
@@ -61,16 +63,64 @@ class ExposedGrantRepository(
                 .bind()
                 .id
 
-            AuthorizationGrantTable
+            val grantRows = AuthorizationGrantTable
                 .selectAll()
                 .where {
                     (AuthorizationGrantTable.grantedTo eq partyId) or (AuthorizationGrantTable.grantedFor eq partyId)
                 }
-                .map { g ->
-                    findInternalGrant(g[AuthorizationGrantTable.id].value)
-                        .mapLeft { RepositoryReadError.UnexpectedError }
-                        .bind()
-                }
+                .toList()
+
+            if (grantRows.isEmpty()) return@transactionContext emptyList()
+
+            val grantIds = grantRows.map { it[AuthorizationGrantTable.id].value }
+
+            // Batch-load all party records needed across all grants in a single query
+            val allPartyIds = grantRows.flatMap {
+                listOfNotNull(
+                    it[AuthorizationGrantTable.grantedBy],
+                    it[AuthorizationGrantTable.grantedFor],
+                    it[AuthorizationGrantTable.grantedTo],
+                )
+            }.distinct()
+            val partyMap: Map<UUID, AuthorizationPartyRecord> = AuthorizationPartyTable
+                .selectAll()
+                .where { AuthorizationPartyTable.id inList allPartyIds }
+                .associate { it[AuthorizationPartyTable.id].value to it.toAuthorizationParty() }
+
+            // Batch-load all scopes for all grants in two queries (join table + scope table)
+            val scopesByGrantId: Map<UUID, List<UUID>> = (AuthorizationGrantScopeTable innerJoin AuthorizationScopeTable)
+                .selectAll()
+                .where { AuthorizationGrantScopeTable.authorizationGrantId inList grantIds }
+                .groupBy(
+                    { it[AuthorizationGrantScopeTable.authorizationGrantId] },
+                    { it[AuthorizationScopeTable.id].value }
+                )
+
+            // Batch-load all properties for all grants in one query
+            val propertiesByGrantId: Map<UUID, List<AuthorizationGrantProperty>> = AuthorizationGrantPropertyTable
+                .selectAll()
+                .where { AuthorizationGrantPropertyTable.grantId inList grantIds }
+                .groupBy(
+                    { it[AuthorizationGrantPropertyTable.grantId] },
+                    { it.toAuthorizationGrantProperty() }
+                )
+
+            grantRows.map { row ->
+                val grantId = row[AuthorizationGrantTable.id].value
+                val grantedBy = partyMap[row[AuthorizationGrantTable.grantedBy]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val grantedFor = partyMap[row[AuthorizationGrantTable.grantedFor]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val grantedTo = partyMap[row[AuthorizationGrantTable.grantedTo]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                row.toAuthorizationGrant(
+                    grantedBy = grantedBy,
+                    grantedFor = grantedFor,
+                    grantedTo = grantedTo,
+                    scopeIds = scopesByGrantId[grantId] ?: emptyList(),
+                    properties = propertiesByGrantId[grantId] ?: emptyList(),
+                )
+            }
         }
 
     override suspend fun find(grantId: UUID): Either<RepositoryReadError, AuthorizationGrant> =
@@ -117,14 +167,6 @@ class ExposedGrantRepository(
         }
 
     fun findScopeIds(grantId: UUID): Either<RepositoryReadError, List<UUID>> = either {
-        AuthorizationGrantTable
-            .selectAll()
-            .where { AuthorizationGrantTable.id eq grantId }
-            .singleOrNull() ?: run {
-            logger.error("Grant not found")
-            raise(RepositoryReadError.NotFoundError)
-        }
-
         (AuthorizationGrantScopeTable innerJoin AuthorizationScopeTable)
             .selectAll()
             .where { AuthorizationGrantScopeTable.authorizationGrantId eq grantId }

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -264,7 +264,8 @@ class ExposedGrantRepository(
             "db_operations",
             "GrantRepository",
             "update",
-            { RepositoryWriteError.UnexpectedError }) {
+            { RepositoryWriteError.UnexpectedError }
+        ) {
             val rowsUpdated =
                 AuthorizationGrantTable.update(
                     where = { AuthorizationGrantTable.id eq grantId }

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -74,7 +74,6 @@ class ExposedGrantRepository(
 
             val grantIds = grantRows.map { it[AuthorizationGrantTable.id].value }
 
-            // Batch-load all party records needed across all grants in a single query
             val allPartyIds = grantRows.flatMap {
                 listOfNotNull(
                     it[AuthorizationGrantTable.grantedBy],
@@ -87,16 +86,15 @@ class ExposedGrantRepository(
                 .where { AuthorizationPartyTable.id inList allPartyIds }
                 .associate { it[AuthorizationPartyTable.id].value to it.toAuthorizationParty() }
 
-            // Batch-load all scopes for all grants in two queries (join table + scope table)
-            val scopesByGrantId: Map<UUID, List<UUID>> = (AuthorizationGrantScopeTable innerJoin AuthorizationScopeTable)
-                .selectAll()
-                .where { AuthorizationGrantScopeTable.authorizationGrantId inList grantIds }
-                .groupBy(
-                    { it[AuthorizationGrantScopeTable.authorizationGrantId] },
-                    { it[AuthorizationScopeTable.id].value }
-                )
+            val scopesByGrantId: Map<UUID, List<UUID>> =
+                (AuthorizationGrantScopeTable innerJoin AuthorizationScopeTable)
+                    .selectAll()
+                    .where { AuthorizationGrantScopeTable.authorizationGrantId inList grantIds }
+                    .groupBy(
+                        { it[AuthorizationGrantScopeTable.authorizationGrantId] },
+                        { it[AuthorizationScopeTable.id].value }
+                    )
 
-            // Batch-load all properties for all grants in one query
             val propertiesByGrantId: Map<UUID, List<AuthorizationGrantProperty>> = AuthorizationGrantPropertyTable
                 .selectAll()
                 .where { AuthorizationGrantPropertyTable.grantId inList grantIds }
@@ -262,7 +260,11 @@ class ExposedGrantRepository(
         }
 
     override suspend fun update(grantId: UUID, newStatus: Status): Either<RepositoryError, AuthorizationGrant> =
-        transactionContext<RepositoryError, AuthorizationGrant>("db_operations", "GrantRepository", "update", { RepositoryWriteError.UnexpectedError }) {
+        transactionContext<RepositoryError, AuthorizationGrant>(
+            "db_operations",
+            "GrantRepository",
+            "update",
+            { RepositoryWriteError.UnexpectedError }) {
             val rowsUpdated =
                 AuthorizationGrantTable.update(
                     where = { AuthorizationGrantTable.id eq grantId }

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestPropertiesRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestPropertiesRepository.kt
@@ -40,7 +40,7 @@ object AuthorizationRequestPropertyTable : Table("auth.authorization_request_pro
     val value = text("value")
 }
 
-private fun ResultRow.toAuthorizationRequestProperty() = AuthorizationRequestProperty(
+internal fun ResultRow.toAuthorizationRequestProperty() = AuthorizationRequestProperty(
     requestId = this[AuthorizationRequestPropertyTable.requestId],
     key = this[AuthorizationRequestPropertyTable.key],
     value = this[AuthorizationRequestPropertyTable.value]

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -135,7 +135,8 @@ class ExposedRequestRepository(
                     ?: raise(RepositoryReadError.UnexpectedError)
                 val requestedTo = partyMap[row[AuthorizationRequestTable.requestedTo]]
                     ?: raise(RepositoryReadError.UnexpectedError)
-                val approvedBy = row[AuthorizationRequestTable.approvedBy]?.let { partyMap[it] }
+                val approvedById = row[AuthorizationRequestTable.approvedBy]
+                val approvedBy = approvedById?.let { partyMap[it] ?: raise(RepositoryReadError.UnexpectedError) }
                 val requestId = row[AuthorizationRequestTable.id].value
                 row.toAuthorizationRequest(
                     requestedBy = requestedBy,

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -13,6 +13,7 @@ import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyRecord
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
 import no.elhub.auth.features.common.party.PartyRepository
+import no.elhub.auth.features.common.party.toAuthorizationParty
 import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.common.AuthorizationGrantProperty
 import no.elhub.auth.features.grants.common.AuthorizationScopeTable
@@ -30,6 +31,7 @@ import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.javatime.timestampWithTimeZone
@@ -90,14 +92,59 @@ class ExposedRequestRepository(
                 .bind()
                 .id
 
-            AuthorizationRequestTable
+            val requestRows = AuthorizationRequestTable
                 .selectAll()
                 .where {
                     (AuthorizationRequestTable.requestedTo eq partyId) or (AuthorizationRequestTable.requestedBy eq partyId)
                 }
                 .orderBy(AuthorizationRequestTable.createdAt to SortOrder.DESC)
                 .toList()
-                .map { row -> findInternal(row).mapLeft { RepositoryReadError.UnexpectedError }.bind() }
+
+            if (requestRows.isEmpty()) return@transactionContext emptyList()
+
+            val requestIds = requestRows.map { it[AuthorizationRequestTable.id].value }
+
+            // Batch-load all party records needed across all requests in a single query
+            val allPartyIds = requestRows.flatMap {
+                listOfNotNull(
+                    it[AuthorizationRequestTable.requestedBy],
+                    it[AuthorizationRequestTable.requestedFrom],
+                    it[AuthorizationRequestTable.requestedTo],
+                    it[AuthorizationRequestTable.approvedBy],
+                )
+            }.distinct()
+            val partyMap: Map<UUID, AuthorizationPartyRecord> = AuthorizationPartyTable
+                .selectAll()
+                .where { AuthorizationPartyTable.id inList allPartyIds }
+                .associate { it[AuthorizationPartyTable.id].value to it.toAuthorizationParty() }
+
+            // Batch-load all properties for all requests in one query
+            val propertiesByRequestId: Map<UUID, List<AuthorizationRequestProperty>> =
+                AuthorizationRequestPropertyTable
+                    .selectAll()
+                    .where { AuthorizationRequestPropertyTable.requestId inList requestIds }
+                    .groupBy(
+                        { it[AuthorizationRequestPropertyTable.requestId] },
+                        { it.toAuthorizationRequestProperty() }
+                    )
+
+            requestRows.map { row ->
+                val requestedBy = partyMap[row[AuthorizationRequestTable.requestedBy]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val requestedFrom = partyMap[row[AuthorizationRequestTable.requestedFrom]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val requestedTo = partyMap[row[AuthorizationRequestTable.requestedTo]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val approvedBy = row[AuthorizationRequestTable.approvedBy]?.let { partyMap[it] }
+                val requestId = row[AuthorizationRequestTable.id].value
+                row.toAuthorizationRequest(
+                    requestedBy = requestedBy,
+                    requestedFrom = requestedFrom,
+                    requestedTo = requestedTo,
+                    properties = propertiesByRequestId[requestId] ?: emptyList(),
+                    approvedBy = approvedBy,
+                )
+            }
         }
 
     override suspend fun find(requestId: UUID): Either<RepositoryReadError, AuthorizationRequest> =

--- a/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
@@ -147,6 +147,13 @@ class ExposedRequestRepositoryTest : FunSpec({
         createdAtList shouldBe createdAtList.sortedDescending()
     }
 
+    test("findAllAndSortByCreatedAt returns empty list for party with no requests") {
+        val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
+        val result = requestRepo.findAllAndSortByCreatedAt(party)
+            .getOrElse { throw AssertionError("Repository read failed: $it") }
+        result shouldBe emptyList()
+    }
+
     test("find returns correct request") {
         val requests = List(10) {
             generateRequestWithoutProperties()


### PR DESCRIPTION
Part of https://elhub.atlassian.net/browse/TDX-1471

These functions would trigger a series of new queries for each result row in the base result set. This is now replaced with batching and dictionary (map) lookups.