### PR TITLE
Refactor findbysource for batching

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/documents/get/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/get/Handler.kt
@@ -30,8 +30,8 @@ class Handler(
             QueryError.NotAuthorizedError
         }
 
-        val grant =
-            grantRepository.findBySource(AuthorizationGrant.SourceType.Document, document.id)
+        val grantsBySourceId =
+            grantRepository.findBySourceIds(AuthorizationGrant.SourceType.Document, listOf(document.id))
                 .mapLeft { error ->
                     when (error) {
                         RepositoryReadError.NotFoundError -> QueryError.ResourceNotFoundError
@@ -39,6 +39,6 @@ class Handler(
                     }
                 }.bind()
 
-        document.copy(grantId = grant?.id)
+        document.copy(grantId = grantsBySourceId[document.id]?.id)
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/Handler.kt
@@ -22,16 +22,17 @@ class Handler(
                 }
             }.bind()
 
-        documents.map { document ->
-            val grant = grantRepository.findBySource(AuthorizationGrant.SourceType.Document, document.id)
-                .mapLeft { error ->
-                    when (error) {
-                        RepositoryReadError.NotFoundError -> QueryError.ResourceNotFoundError
-                        RepositoryReadError.UnexpectedError -> QueryError.IOError
-                    }
-                }.bind()
+        val documentIds = documents.map { it.id }
+        val grantsBySourceId = grantRepository.findBySourceIds(AuthorizationGrant.SourceType.Document, documentIds)
+            .mapLeft { error ->
+                when (error) {
+                    RepositoryReadError.NotFoundError -> QueryError.ResourceNotFoundError
+                    RepositoryReadError.UnexpectedError -> QueryError.IOError
+                }
+            }.bind()
 
-            document.copy(grantId = grant?.id)
+        documents.map { document ->
+            document.copy(grantId = grantsBySourceId[document.id]?.id)
         }
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -36,7 +36,7 @@ import java.util.UUID
 
 interface GrantRepository {
     suspend fun find(grantId: UUID): Either<RepositoryReadError, AuthorizationGrant>
-    suspend fun findBySource(sourceType: SourceType, sourceId: UUID): Either<RepositoryReadError, AuthorizationGrant?>
+    suspend fun findBySourceIds(sourceType: SourceType, sourceIds: List<UUID>): Either<RepositoryReadError, Map<UUID, AuthorizationGrant>>
     suspend fun findScopes(grantId: UUID): Either<RepositoryReadError, List<AuthorizationScope>>
     suspend fun findAll(party: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationGrant>>
     suspend fun insert(grant: AuthorizationGrant): Either<RepositoryWriteError, AuthorizationGrant>
@@ -131,37 +131,76 @@ class ExposedGrantRepository(
             findInternalGrant(grantId).bind()
         }
 
-    override suspend fun findBySource(
+    override suspend fun findBySourceIds(
         sourceType: SourceType,
-        sourceId: UUID
-    ): Either<RepositoryReadError, AuthorizationGrant?> =
-        transactionContext<RepositoryReadError, AuthorizationGrant?>(
+        sourceIds: List<UUID>,
+    ): Either<RepositoryReadError, Map<UUID, AuthorizationGrant>> =
+        transactionContext<RepositoryReadError, Map<UUID, AuthorizationGrant>>(
             "db_operations",
             "GrantRepository",
-            "findBySource",
-            ({ RepositoryReadError.UnexpectedError })
+            "findBySourceIds",
+            { RepositoryReadError.UnexpectedError }
         ) {
-            AuthorizationGrantTable
+            if (sourceIds.isEmpty()) return@transactionContext emptyMap()
+
+            val grantRows = AuthorizationGrantTable
                 .selectAll()
                 .where {
-                    (AuthorizationGrantTable.sourceType eq sourceType) and (AuthorizationGrantTable.sourceId eq sourceId)
+                    (AuthorizationGrantTable.sourceType eq sourceType) and
+                        (AuthorizationGrantTable.sourceId inList sourceIds)
                 }
-                .singleOrNull()
-                ?.let { grant ->
-                    val grantedFor = partyRepository.find(grant[AuthorizationGrantTable.grantedFor]).bind()
-                    val grantedBy = partyRepository.find(grant[AuthorizationGrantTable.grantedBy]).bind()
-                    val grantedTo = partyRepository.find(grant[AuthorizationGrantTable.grantedTo]).bind()
-                    val scopes = findScopeIds(grant[AuthorizationGrantTable.id].value).bind()
-                    val properties = grantPropertiesRepository.findBy(grant[AuthorizationGrantTable.id].value)
+                .toList()
 
-                    grant.toAuthorizationGrant(
-                        grantedBy = grantedBy,
-                        grantedFor = grantedFor,
-                        grantedTo = grantedTo,
-                        scopeIds = scopes,
-                        properties = properties
+            if (grantRows.isEmpty()) return@transactionContext emptyMap()
+
+            val grantIds = grantRows.map { it[AuthorizationGrantTable.id].value }
+
+            val allPartyIds = grantRows.flatMap {
+                listOfNotNull(
+                    it[AuthorizationGrantTable.grantedBy],
+                    it[AuthorizationGrantTable.grantedFor],
+                    it[AuthorizationGrantTable.grantedTo],
+                )
+            }.distinct()
+            val partyMap: Map<UUID, AuthorizationPartyRecord> = AuthorizationPartyTable
+                .selectAll()
+                .where { AuthorizationPartyTable.id inList allPartyIds }
+                .associate { it[AuthorizationPartyTable.id].value to it.toAuthorizationParty() }
+
+            val scopesByGrantId: Map<UUID, List<UUID>> =
+                (AuthorizationGrantScopeTable innerJoin AuthorizationScopeTable)
+                    .selectAll()
+                    .where { AuthorizationGrantScopeTable.authorizationGrantId inList grantIds }
+                    .groupBy(
+                        { it[AuthorizationGrantScopeTable.authorizationGrantId] },
+                        { it[AuthorizationScopeTable.id].value }
                     )
-                }
+
+            val propertiesByGrantId: Map<UUID, List<AuthorizationGrantProperty>> = AuthorizationGrantPropertyTable
+                .selectAll()
+                .where { AuthorizationGrantPropertyTable.grantId inList grantIds }
+                .groupBy(
+                    { it[AuthorizationGrantPropertyTable.grantId] },
+                    { it.toAuthorizationGrantProperty() }
+                )
+
+            grantRows.associate { row ->
+                val grantId = row[AuthorizationGrantTable.id].value
+                val grantedBy = partyMap[row[AuthorizationGrantTable.grantedBy]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val grantedFor = partyMap[row[AuthorizationGrantTable.grantedFor]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val grantedTo = partyMap[row[AuthorizationGrantTable.grantedTo]]
+                    ?: raise(RepositoryReadError.UnexpectedError)
+                val grant = row.toAuthorizationGrant(
+                    grantedBy = grantedBy,
+                    grantedFor = grantedFor,
+                    grantedTo = grantedTo,
+                    scopeIds = scopesByGrantId[grantId] ?: emptyList(),
+                    properties = propertiesByGrantId[grantId] ?: emptyList(),
+                )
+                row[AuthorizationGrantTable.sourceId] to grant
+            }
         }
 
     fun findScopeIds(grantId: UUID): Either<RepositoryReadError, List<UUID>> = either {

--- a/src/main/kotlin/no/elhub/auth/features/requests/get/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/get/Handler.kt
@@ -29,14 +29,18 @@ class Handler(
 
         // grant can only exist if approvedBy is set
         request.approvedBy?.let {
-            val grant = grantRepository.findBySource(
+            val grantsBySourceId = grantRepository.findBySourceIds(
                 AuthorizationGrant.SourceType.Request,
-                request.id
+                listOf(request.id)
             ).mapLeft {
-                logger.error("approvedBy is present but grant not found for request ${request.id}")
-                QueryError.ResourceNotFoundError
+                logger.error("Failed to fetch grant for request ${request.id}")
+                QueryError.IOError
             }.bind()
 
+            val grant = grantsBySourceId[request.id]
+            if (grant == null) {
+                logger.error("approvedBy is present but grant not found for request ${request.id}")
+            }
             grant?.let { request.copy(grantId = it.id) } ?: request
         } ?: request
     }

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/Handler.kt
@@ -21,19 +21,26 @@ class Handler(
             .mapLeft { QueryError.ResourceNotFoundError }
             .bind()
 
+        val approvedRequestIds = list.mapNotNull { request ->
+            request.id.takeIf { request.approvedBy != null }
+        }
+
+        val grantsBySourceId = grantRepository.findBySourceIds(
+            AuthorizationGrant.SourceType.Request,
+            approvedRequestIds
+        ).mapLeft {
+            logger.error("Failed to batch-fetch grants for approved requests")
+            QueryError.IOError
+        }.bind()
+
         list.map { request ->
             if (request.approvedBy == null) {
-                return@map request
+                request
             } else {
-                // grant can only exist if approvedBy is set
-                val grant = grantRepository.findBySource(
-                    AuthorizationGrant.SourceType.Request,
-                    request.id
-                ).mapLeft {
+                val grant = grantsBySourceId[request.id]
+                if (grant == null) {
                     logger.error("approvedBy is present but grant not found for request ${request.id}")
-                    QueryError.ResourceNotFoundError
-                }.bind()
-
+                }
                 grant?.let { request.copy(grantId = it.id) } ?: request
             }
         }

--- a/src/test/kotlin/no/elhub/auth/features/documents/get/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/get/HandlerTest.kt
@@ -67,7 +67,8 @@ class HandlerTest : FunSpec({
 
     fun grantRepoReturning(result: Either<RepositoryReadError, AuthorizationGrant?>): GrantRepository =
         mockk<GrantRepository> {
-            coEvery { findBySource(AuthorizationGrant.SourceType.Document, documentId) } returns result
+            coEvery { findBySourceIds(AuthorizationGrant.SourceType.Document, listOf(documentId)) } returns
+                result.map { grant -> grant?.let { mapOf(documentId to it) } ?: emptyMap() }
         }
 
     test("returns document with grant id when authorized party matches requestedBy") {

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
@@ -79,24 +79,18 @@ class HandlerTest : FunSpec({
             coEvery { findAll(any()) } returns result
         }
 
-    fun grantRepoReturning(
-        firstResult: Either<RepositoryReadError, AuthorizationGrant?>,
-        secondResult: Either<RepositoryReadError, AuthorizationGrant?>
-    ): GrantRepository =
+    fun grantRepoReturning(result: Either<RepositoryReadError, Map<UUID, AuthorizationGrant>>): GrantRepository =
         mockk<GrantRepository> {
             coEvery {
-                findBySource(AuthorizationGrant.SourceType.Document, firstDocumentId)
-            } returns firstResult
-            coEvery {
-                findBySource(AuthorizationGrant.SourceType.Document, secondDocumentId)
-            } returns secondResult
+                findBySourceIds(AuthorizationGrant.SourceType.Document, any())
+            } returns result
         }
 
     test("returns documents with grant ids resolved for authorized party") {
-        val noGrant: Either<RepositoryReadError, AuthorizationGrant?> = null.right()
-
         val documentRepo = documentRepoReturning(listOf(firstDocument, secondDocument).right())
-        val handler = Handler(documentRepo, grantRepoReturning(grant.right(), noGrant))
+        // first document has a grant, second does not
+        val grantMap = mapOf(firstDocumentId to grant)
+        val handler = Handler(documentRepo, grantRepoReturning(grantMap.right()))
 
         val response = handler(
             Query(

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -146,6 +146,34 @@ class ExposedGrantRepositoryTest : FunSpec({
         result[UUID.fromString("4f71d596-99e4-415e-946d-7252c1a40c50")].shouldNotBeNull()
     }
 
+    test("findBySourceIds returns multiple grants for multiple source ids") {
+        insertTestData()
+        val sourceId1 = UUID.fromString("4f71d596-99e4-415e-946d-7252c1a40c50")
+        val sourceId2 = UUID.fromString("4f71d596-99e4-415e-946d-7252c1a40c51")
+        val sourceId3 = UUID.fromString("8150d80b-3a48-401e-a6d5-025bd3aa1254")
+        val result = grantRepo.findBySourceIds(
+            sourceType = AuthorizationGrant.SourceType.Request,
+            sourceIds = listOf(sourceId1, sourceId2, sourceId3)
+        ).getOrElse {
+            fail("Failed to read grants by source ids")
+        }
+        result.size shouldBe 3
+        result[sourceId1].shouldNotBeNull()
+        result[sourceId2].shouldNotBeNull()
+        result[sourceId3].shouldNotBeNull()
+    }
+
+    test("findBySourceIds returns empty map for empty source id list") {
+        insertTestData()
+        val result = grantRepo.findBySourceIds(
+            sourceType = AuthorizationGrant.SourceType.Request,
+            sourceIds = emptyList()
+        ).getOrElse {
+            fail("Failed to read grants by source ids")
+        }
+        result.size shouldBe 0
+    }
+
     test("findScopes returns correct number of scopes given grantId") {
         insertTestData()
         val scopes = grantRepo.findScopes(grantId = UUID.fromString("b7f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a"))

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -135,15 +135,15 @@ class ExposedGrantRepositoryTest : FunSpec({
         resultForPartyWithoutGrants.size shouldBe 0
     }
 
-    test("findBySource returns grant given sourceType and sourceId)") {
+    test("findBySourceIds returns grant given sourceType and sourceId") {
         insertTestData()
-        val grant = grantRepo.findBySource(
+        val result = grantRepo.findBySourceIds(
             sourceType = AuthorizationGrant.SourceType.Request,
-            sourceId = UUID.fromString("4f71d596-99e4-415e-946d-7252c1a40c50")
+            sourceIds = listOf(UUID.fromString("4f71d596-99e4-415e-946d-7252c1a40c50"))
         ).getOrElse {
-            fail("Failed to read grants by source")
+            fail("Failed to read grants by source ids")
         }
-        grant.shouldNotBeNull()
+        result[UUID.fromString("4f71d596-99e4-415e-946d-7252c1a40c50")].shouldNotBeNull()
     }
 
     test("findScopes returns correct number of scopes given grantId") {


### PR DESCRIPTION
More work resulting from https://elhub.atlassian.net/browse/TDX-1471

Another N+1 query problem discovered, where the `requests/query` handler would trigger a new `findBySource` for each entry in the requests result set. This is now replaced with `findBySourceIds` to generate a constant number of db calls from that class.