### PR TITLE
Implement pagination for list endpoints [minor]

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
@@ -51,4 +51,3 @@ fun <T> Page<T>.toPaginationLinks(basePath: String): PaginationLinks {
         next = if (p.page < lastPage) pageUrl(p.page + 1) else null,
     )
 }
-

--- a/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
@@ -1,0 +1,29 @@
+package no.elhub.auth.features.common
+
+import kotlin.math.ceil
+
+const val DEFAULT_PAGE_SIZE = 20
+const val MAX_PAGE_SIZE = 100
+
+data class Pagination(
+    val page: Int = 0,
+    val size: Int = DEFAULT_PAGE_SIZE,
+) {
+    val offset: Long get() = page.toLong() * size
+
+    companion object {
+        fun from(pageParam: String?, sizeParam: String?): Pagination {
+            val size = sizeParam?.toIntOrNull()?.coerceIn(1, MAX_PAGE_SIZE) ?: DEFAULT_PAGE_SIZE
+            val page = pageParam?.toIntOrNull()?.coerceAtLeast(0) ?: 0
+            return Pagination(page = page, size = size)
+        }
+    }
+}
+
+data class Page<T>(
+    val items: List<T>,
+    val totalItems: Long,
+    val pagination: Pagination,
+) {
+    val totalPages: Int = if (pagination.size == 0) 0 else ceil(totalItems.toDouble() / pagination.size).toInt()
+}

--- a/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
@@ -2,7 +2,7 @@ package no.elhub.auth.features.common
 
 import kotlin.math.ceil
 
-const val DEFAULT_PAGE_SIZE = 20
+const val DEFAULT_PAGE_SIZE = 30
 const val MAX_PAGE_SIZE = 100
 
 data class Pagination(

--- a/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Pagination.kt
@@ -1,5 +1,7 @@
 package no.elhub.auth.features.common
 
+import kotlinx.serialization.Serializable
+import no.elhub.devxp.jsonapi.model.JsonApiResourceLinks
 import kotlin.math.ceil
 
 const val DEFAULT_PAGE_SIZE = 30
@@ -27,3 +29,26 @@ data class Page<T>(
 ) {
     val totalPages: Int = if (pagination.size == 0) 0 else ceil(totalItems.toDouble() / pagination.size).toInt()
 }
+
+@Serializable
+data class PaginationLinks(
+    val self: String,
+    val first: String,
+    val last: String,
+    val prev: String? = null,
+    val next: String? = null,
+) : JsonApiResourceLinks
+
+fun <T> Page<T>.toPaginationLinks(basePath: String): PaginationLinks {
+    val p = pagination
+    val lastPage = (totalPages - 1).coerceAtLeast(0)
+    fun pageUrl(pageNum: Int) = "$basePath?page[number]=$pageNum&page[size]=${p.size}"
+    return PaginationLinks(
+        self = pageUrl(p.page),
+        first = pageUrl(0),
+        last = pageUrl(lastPage),
+        prev = if (p.page > 0) pageUrl(p.page - 1) else null,
+        next = if (p.page < lastPage) pageUrl(p.page + 1) else null,
+    )
+}
+

--- a/src/main/kotlin/no/elhub/auth/features/common/dto/PaginatedCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/dto/PaginatedCollectionResponse.kt
@@ -1,0 +1,17 @@
+package no.elhub.auth.features.common.dto
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+import no.elhub.auth.features.common.PaginationLinks
+
+/**
+ * A generic JSON:API-shaped collection response with pagination links and meta.
+ *
+ * Used in place of the devxp library's collection types which only support a `self` link.
+ */
+@Serializable
+data class PaginatedCollectionResponse<DATA>(
+    val data: List<DATA>,
+    val links: PaginationLinks,
+    val meta: JsonObject,
+)

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -3,6 +3,8 @@ package no.elhub.auth.features.documents.common
 import arrow.core.Either
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.features.common.CreateScopeData
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.PGEnum
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
@@ -25,6 +27,7 @@ import no.elhub.auth.features.grants.common.GrantPropertiesRepository
 import no.elhub.auth.features.grants.common.GrantRepository
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
@@ -58,7 +61,7 @@ interface DocumentRepository {
         scopes: List<CreateScopeData>
     ): Either<RepositoryWriteError, AuthorizationDocument>
 
-    suspend fun findAll(requestedBy: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationDocument>>
+    suspend fun findAll(requestedBy: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationDocument>>
 
     suspend fun findScopeIds(documentId: UUID): Either<RepositoryReadError, List<UUID>>
 
@@ -219,8 +222,8 @@ class ExposedDocumentRepository(
                 .map { row -> row[AuthorizationScopeTable.id].value }
         }
 
-    override suspend fun findAll(requestedBy: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationDocument>> =
-        transactionContext<RepositoryReadError, List<AuthorizationDocument>>(
+    override suspend fun findAll(requestedBy: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationDocument>> =
+        transactionContext<RepositoryReadError, Page<AuthorizationDocument>>(
             "db_operations",
             "DocumenRepository",
             "findAll",
@@ -230,21 +233,37 @@ class ExposedDocumentRepository(
                 .mapLeft { RepositoryReadError.UnexpectedError }
                 .bind()
 
-            val documentWithSignatoryRecords = (AuthorizationDocumentTable leftJoin SignatoriesTable)
-                .select(AuthorizationDocumentTable.columns + SignatoriesTable.signedBy)
-                .where { (AuthorizationDocumentTable.requestedBy eq partyRecord.id) or (AuthorizationDocumentTable.requestedFrom eq partyRecord.id) }
+            val whereClause = { (AuthorizationDocumentTable.requestedBy eq partyRecord.id) or (AuthorizationDocumentTable.requestedFrom eq partyRecord.id) }
+
+            val totalItems = AuthorizationDocumentTable
+                .selectAll()
+                .where(whereClause)
+                .count()
+
+            val documentRows = AuthorizationDocumentTable
+                .selectAll()
+                .where(whereClause)
+                .orderBy(AuthorizationDocumentTable.createdAt to SortOrder.DESC)
+                .limit(pagination.size)
+                .offset(pagination.offset)
                 .toList()
 
-            if (documentWithSignatoryRecords.isEmpty()) return@transactionContext emptyList()
+            if (documentRows.isEmpty()) return@transactionContext Page(emptyList(), totalItems, pagination)
 
-            val partyIds = documentWithSignatoryRecords.flatMap { row ->
+            val documentIds = documentRows.map { it[AuthorizationDocumentTable.id].value }
+
+            val signatoryByDocumentId = SignatoriesTable
+                .select(listOf(SignatoriesTable.authorizationDocumentId, SignatoriesTable.signedBy))
+                .where { SignatoriesTable.authorizationDocumentId inList documentIds }
+                .associate { it[SignatoriesTable.authorizationDocumentId] to it[SignatoriesTable.signedBy] }
+
+            val partyIds = documentRows.flatMap { row ->
                 setOfNotNull(
                     row[AuthorizationDocumentTable.requestedBy],
                     row[AuthorizationDocumentTable.requestedFrom],
                     row[AuthorizationDocumentTable.requestedTo],
-                    row[SignatoriesTable.signedBy]
                 )
-            }.toSet()
+            }.toMutableSet().also { it.addAll(signatoryByDocumentId.values) }
 
             val partiesById = AuthorizationPartyTable
                 .selectAll()
@@ -254,15 +273,16 @@ class ExposedDocumentRepository(
                     party.id to party
                 }
 
-            documentWithSignatoryRecords.map { row ->
+            val items = documentRows.map { row ->
                 val requestedByParty = partiesById[row[AuthorizationDocumentTable.requestedBy]]
                     ?: raise(RepositoryReadError.UnexpectedError)
                 val requestedFromParty = partiesById[row[AuthorizationDocumentTable.requestedFrom]]
                     ?: raise(RepositoryReadError.UnexpectedError)
                 val requestedToParty = partiesById[row[AuthorizationDocumentTable.requestedTo]]
                     ?: raise(RepositoryReadError.UnexpectedError)
-                val signedByParty = partiesById[row[SignatoriesTable.signedBy]]
-                val properties = documentPropertiesRepository.find(row[AuthorizationDocumentTable.id].value)
+                val docId = row[AuthorizationDocumentTable.id].value
+                val signedByParty = signatoryByDocumentId[docId]?.let { partiesById[it] }
+                val properties = documentPropertiesRepository.find(docId)
 
                 row.toAuthorizationDocument(
                     requestedByParty,
@@ -272,6 +292,8 @@ class ExposedDocumentRepository(
                     signedByParty
                 )
             }
+
+            Page(items = items, totalItems = totalItems, pagination = pagination)
         }
 
     private suspend fun resolveParty(partyId: UUID): Either<RepositoryReadError.UnexpectedError, AuthorizationPartyRecord> =

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -3,9 +3,9 @@ package no.elhub.auth.features.documents.common
 import arrow.core.Either
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.features.common.CreateScopeData
+import no.elhub.auth.features.common.PGEnum
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.Pagination
-import no.elhub.auth.features.common.PGEnum
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.currentTimeUtc

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/Handler.kt
@@ -2,6 +2,7 @@ package no.elhub.auth.features.documents.query
 
 import arrow.core.Either
 import arrow.core.raise.either
+import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.QueryError
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.documents.AuthorizationDocument
@@ -13,8 +14,8 @@ class Handler(
     private val repo: DocumentRepository,
     private val grantRepository: GrantRepository
 ) {
-    suspend operator fun invoke(query: Query): Either<QueryError, List<AuthorizationDocument>> = either {
-        val documents = repo.findAll(query.authorizedParty)
+    suspend operator fun invoke(query: Query): Either<QueryError, Page<AuthorizationDocument>> = either {
+        val page = repo.findAll(query.authorizedParty, query.pagination)
             .mapLeft { error ->
                 when (error) {
                     is RepositoryReadError.NotFoundError -> QueryError.ResourceNotFoundError
@@ -22,7 +23,7 @@ class Handler(
                 }
             }.bind()
 
-        documents.map { document ->
+        val enrichedItems = page.items.map { document ->
             val grant = grantRepository.findBySource(AuthorizationGrant.SourceType.Document, document.id)
                 .mapLeft { error ->
                     when (error) {
@@ -33,5 +34,7 @@ class Handler(
 
             document.copy(grantId = grant?.id)
         }
+
+        page.copy(items = enrichedItems)
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/Handler.kt
@@ -32,10 +32,10 @@ class Handler(
                 }
             }.bind()
 
-        val enrichedItems = page.items.map { document ->
-            document.copy(grantId = grantsBySourceId[document.id]?.id)
-        }
-
-        page.copy(items = enrichedItems)
+        page.copy(
+            items = page.items.map { document ->
+                document.copy(grantId = grantsBySourceId[document.id]?.id)
+            }
+        )
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/Query.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/Query.kt
@@ -1,7 +1,9 @@
 package no.elhub.auth.features.documents.query
 
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 
 data class Query(
-    val authorizedParty: AuthorizationParty
+    val authorizedParty: AuthorizationParty,
+    val pagination: Pagination = Pagination(),
 )

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/Route.kt
@@ -5,6 +5,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
 import no.elhub.auth.features.common.toApiErrorResponse
@@ -22,9 +23,14 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
                 return@get
             }
 
-        val query = Query(authorizedParty = authorizedParty)
+        val pagination = Pagination.from(
+            pageParam = call.request.queryParameters["page[number]"],
+            sizeParam = call.request.queryParameters["page[size]"],
+        )
 
-        val documents = handler(query)
+        val query = Query(authorizedParty = authorizedParty, pagination = pagination)
+
+        val page = handler(query)
             .getOrElse { error ->
                 logger.error("Failed to get authorization documents: {}", error)
                 val (status, body) = error.toApiErrorResponse()
@@ -32,6 +38,6 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
                 return@get
             }
 
-        call.respond(HttpStatusCode.OK, documents.toGetCollectionResponse())
+        call.respond(HttpStatusCode.OK, page.toGetCollectionResponse())
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/dto/JsonApiGetCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/dto/JsonApiGetCollectionResponse.kt
@@ -7,10 +7,12 @@ import no.elhub.auth.features.common.currentTimeOslo
 import no.elhub.auth.features.common.dto.JsonApiResourceMetaMap
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.DOCUMENTS_PATH
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseAttributes
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseLinks
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseRelationships
 import no.elhub.auth.features.documents.get.dto.toGetSingleResponse
+import no.elhub.devxp.jsonapi.model.JsonApiLinks
 import no.elhub.devxp.jsonapi.model.JsonApiMeta
 import no.elhub.devxp.jsonapi.response.JsonApiResponse
 
@@ -26,6 +28,7 @@ fun Page<AuthorizationDocument>.toGetCollectionResponse(): GetDocumentCollection
 
     return GetDocumentCollectionResponse(
         data = this.items.map { it.toGetSingleResponse().data },
+        links = JsonApiLinks.ResourceObjectLink(DOCUMENTS_PATH),
         meta = JsonApiMeta(
             buildJsonObject {
                 put("createdAt", currentTimeOslo().toTimeZoneOffsetString())

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/dto/JsonApiGetCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/dto/JsonApiGetCollectionResponse.kt
@@ -2,16 +2,15 @@ package no.elhub.auth.features.documents.query.dto
 
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.currentTimeOslo
 import no.elhub.auth.features.common.dto.JsonApiResourceMetaMap
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.documents.AuthorizationDocument
-import no.elhub.auth.features.documents.DOCUMENTS_PATH
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseAttributes
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseLinks
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseRelationships
 import no.elhub.auth.features.documents.get.dto.toGetSingleResponse
-import no.elhub.devxp.jsonapi.model.JsonApiLinks
 import no.elhub.devxp.jsonapi.model.JsonApiMeta
 import no.elhub.devxp.jsonapi.response.JsonApiResponse
 
@@ -22,14 +21,19 @@ typealias GetDocumentCollectionResponse = JsonApiResponse.CollectionDocumentWith
     AuthorizationDocumentResponseLinks
     >
 
-fun List<AuthorizationDocument>.toGetCollectionResponse() = GetDocumentCollectionResponse(
-    data = this.map {
-        it.toGetSingleResponse().data
-    },
-    links = JsonApiLinks.ResourceObjectLink(DOCUMENTS_PATH),
-    meta = JsonApiMeta(
-        buildJsonObject {
-            put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
-        }
+fun Page<AuthorizationDocument>.toGetCollectionResponse(): GetDocumentCollectionResponse {
+    val p = this.pagination
+
+    return GetDocumentCollectionResponse(
+        data = this.items.map { it.toGetSingleResponse().data },
+        meta = JsonApiMeta(
+            buildJsonObject {
+                put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
+                put("totalItems", this@toGetCollectionResponse.totalItems)
+                put("totalPages", this@toGetCollectionResponse.totalPages)
+                put("page", p.page)
+                put("pageSize", p.size)
+            }
+        )
     )
-)
+}

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/dto/JsonApiGetCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/dto/JsonApiGetCollectionResponse.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.json.put
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.currentTimeOslo
 import no.elhub.auth.features.common.dto.JsonApiResourceMetaMap
+import no.elhub.auth.features.common.dto.PaginatedCollectionResponse
+import no.elhub.auth.features.common.toPaginationLinks
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.DOCUMENTS_PATH
@@ -12,15 +14,15 @@ import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponse
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseLinks
 import no.elhub.auth.features.documents.common.dto.AuthorizationDocumentResponseRelationships
 import no.elhub.auth.features.documents.get.dto.toGetSingleResponse
-import no.elhub.devxp.jsonapi.model.JsonApiLinks
-import no.elhub.devxp.jsonapi.model.JsonApiMeta
-import no.elhub.devxp.jsonapi.response.JsonApiResponse
+import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks
 
-typealias GetDocumentCollectionResponse = JsonApiResponse.CollectionDocumentWithRelationshipsAndMetaAndLinks<
-    AuthorizationDocumentResponseAttributes,
-    AuthorizationDocumentResponseRelationships,
-    JsonApiResourceMetaMap,
-    AuthorizationDocumentResponseLinks
+typealias GetDocumentCollectionResponse = PaginatedCollectionResponse<
+    JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks<
+        AuthorizationDocumentResponseAttributes,
+        AuthorizationDocumentResponseRelationships,
+        JsonApiResourceMetaMap,
+        AuthorizationDocumentResponseLinks
+        >
     >
 
 fun Page<AuthorizationDocument>.toGetCollectionResponse(): GetDocumentCollectionResponse {
@@ -28,15 +30,13 @@ fun Page<AuthorizationDocument>.toGetCollectionResponse(): GetDocumentCollection
 
     return GetDocumentCollectionResponse(
         data = this.items.map { it.toGetSingleResponse().data },
-        links = JsonApiLinks.ResourceObjectLink(DOCUMENTS_PATH),
-        meta = JsonApiMeta(
-            buildJsonObject {
-                put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
-                put("totalItems", this@toGetCollectionResponse.totalItems)
-                put("totalPages", this@toGetCollectionResponse.totalPages)
-                put("page", p.page)
-                put("pageSize", p.size)
-            }
-        )
+        links = toPaginationLinks(DOCUMENTS_PATH),
+        meta = buildJsonObject {
+            put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
+            put("totalItems", this@toGetCollectionResponse.totalItems)
+            put("totalPages", this@toGetCollectionResponse.totalPages)
+            put("page", p.page)
+            put("pageSize", p.size)
+        }
     )
 }

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -8,6 +8,8 @@ import no.elhub.auth.features.common.RepositoryError
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.currentTimeUtc
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyRecord
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
@@ -38,7 +40,7 @@ interface GrantRepository {
     suspend fun find(grantId: UUID): Either<RepositoryReadError, AuthorizationGrant>
     suspend fun findBySource(sourceType: SourceType, sourceId: UUID): Either<RepositoryReadError, AuthorizationGrant?>
     suspend fun findScopes(grantId: UUID): Either<RepositoryReadError, List<AuthorizationScope>>
-    suspend fun findAll(party: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationGrant>>
+    suspend fun findAll(party: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationGrant>>
     suspend fun insert(grant: AuthorizationGrant): Either<RepositoryWriteError, AuthorizationGrant>
     suspend fun update(grantId: UUID, newStatus: Status): Either<RepositoryError, AuthorizationGrant>
 }
@@ -51,8 +53,8 @@ class ExposedGrantRepository(
 
     private val logger = LoggerFactory.getLogger(ExposedGrantRepository::class.java)
 
-    override suspend fun findAll(party: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationGrant>> =
-        transactionContext<RepositoryReadError, List<AuthorizationGrant>>(
+    override suspend fun findAll(party: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationGrant>> =
+        transactionContext<RepositoryReadError, Page<AuthorizationGrant>>(
             "db_operations",
             "GrantRepository",
             "findAll",
@@ -63,14 +65,22 @@ class ExposedGrantRepository(
                 .bind()
                 .id
 
+            val whereClause = { (AuthorizationGrantTable.grantedTo eq partyId) or (AuthorizationGrantTable.grantedFor eq partyId) }
+
+            val totalItems = AuthorizationGrantTable
+                .selectAll()
+                .where(whereClause)
+                .count()
+
             val grantRows = AuthorizationGrantTable
                 .selectAll()
-                .where {
-                    (AuthorizationGrantTable.grantedTo eq partyId) or (AuthorizationGrantTable.grantedFor eq partyId)
-                }
+                .where(whereClause)
+                .orderBy(AuthorizationGrantTable.createdAt to org.jetbrains.exposed.v1.core.SortOrder.DESC)
+                .limit(pagination.size)
+                .offset(pagination.offset)
                 .toList()
 
-            if (grantRows.isEmpty()) return@transactionContext emptyList()
+            if (grantRows.isEmpty()) return@transactionContext Page(emptyList(), totalItems, pagination)
 
             val grantIds = grantRows.map { it[AuthorizationGrantTable.id].value }
 
@@ -103,7 +113,7 @@ class ExposedGrantRepository(
                     { it.toAuthorizationGrantProperty() }
                 )
 
-            grantRows.map { row ->
+            val items = grantRows.map { row ->
                 val grantId = row[AuthorizationGrantTable.id].value
                 val grantedBy = partyMap[row[AuthorizationGrantTable.grantedBy]]
                     ?: raise(RepositoryReadError.UnexpectedError)
@@ -119,6 +129,8 @@ class ExposedGrantRepository(
                     properties = propertiesByGrantId[grantId] ?: emptyList(),
                 )
             }
+
+            Page(items = items, totalItems = totalItems, pagination = pagination)
         }
 
     override suspend fun find(grantId: UUID): Either<RepositoryReadError, AuthorizationGrant> =

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -19,6 +19,7 @@ import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.AuthorizationGrant.SourceType
 import no.elhub.auth.features.grants.AuthorizationGrant.Status
 import no.elhub.auth.features.grants.AuthorizationScope
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
@@ -75,7 +76,7 @@ class ExposedGrantRepository(
             val grantRows = AuthorizationGrantTable
                 .selectAll()
                 .where(whereClause)
-                .orderBy(AuthorizationGrantTable.createdAt to org.jetbrains.exposed.v1.core.SortOrder.DESC)
+                .orderBy(AuthorizationGrantTable.createdAt to SortOrder.DESC)
                 .limit(pagination.size)
                 .offset(pagination.offset)
                 .toList()

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -4,12 +4,12 @@ import arrow.core.Either
 import arrow.core.raise.either
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.features.common.PGEnum
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.RepositoryError
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.currentTimeUtc
-import no.elhub.auth.features.common.Page
-import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyRecord
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
@@ -19,9 +19,9 @@ import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.AuthorizationGrant.SourceType
 import no.elhub.auth.features.grants.AuthorizationGrant.Status
 import no.elhub.auth.features.grants.AuthorizationScope
-import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.ReferenceOption
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
@@ -3,6 +3,7 @@ package no.elhub.auth.features.grants.common.dto
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.currentTimeOslo
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.documents.DOCUMENTS_PATH
@@ -16,8 +17,11 @@ import no.elhub.devxp.jsonapi.model.JsonApiRelationshipData
 import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToMany
 import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToOne
 import no.elhub.devxp.jsonapi.model.JsonApiRelationships
+import no.elhub.devxp.jsonapi.model.JsonApiResourceLinks
+import no.elhub.devxp.jsonapi.model.JsonApiResourceMeta
 import no.elhub.devxp.jsonapi.response.JsonApiResponse
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationships
+import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks
 
 @Serializable
 data class GrantResponseAttributes(
@@ -38,14 +42,24 @@ data class GrantResponseRelationShips(
     val scopes: JsonApiRelationshipToMany
 ) : JsonApiRelationships
 
+/** Per-item links for a grant in a collection response (just `self`). */
+@Serializable
+data class GrantItemLinks(val self: String) : JsonApiResourceLinks
+
+@Serializable
+@JvmInline
+value class GrantCollectionItemMeta(private val dummy: String = "") : JsonApiResourceMeta
+
 typealias SingleGrantResponse = JsonApiResponse.SingleDocumentWithRelationships<
     GrantResponseAttributes,
     GrantResponseRelationShips,
     >
 
-typealias CollectionGrantResponse = JsonApiResponse.CollectionDocumentWithRelationships<
+typealias CollectionGrantResponse = JsonApiResponse.CollectionDocumentWithRelationshipsAndMetaAndLinks<
     GrantResponseAttributes,
     GrantResponseRelationShips,
+    GrantCollectionItemMeta,
+    GrantItemLinks,
     >
 
 fun AuthorizationGrant.toSingleGrantResponse() =
@@ -123,10 +137,12 @@ fun AuthorizationGrant.toSingleGrantResponse() =
         )
     )
 
-fun List<AuthorizationGrant>.toCollectionGrantResponse() =
-    CollectionGrantResponse(
-        data = this.map { grant ->
-            JsonApiResponseResourceObjectWithRelationships(
+fun Page<AuthorizationGrant>.toCollectionGrantResponse(): CollectionGrantResponse {
+    val p = this.pagination
+
+    return CollectionGrantResponse(
+        data = this.items.map { grant ->
+            JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks(
                 type = "AuthorizationGrant",
                 id = grant.id.toString(),
                 attributes = GrantResponseAttributes(
@@ -180,22 +196,18 @@ fun List<AuthorizationGrant>.toCollectionGrantResponse() =
                         }
                     )
                 ),
-                meta = grant.properties.takeIf { it.isNotEmpty() }?.let {
-                    JsonApiMeta(
-                        buildJsonObject {
-                            grant.properties.forEach { prop ->
-                                put(prop.key, prop.value)
-                            }
-                        }
-                    )
-                },
-                links = JsonApiLinks.ResourceObjectLink("$GRANTS_PATH/${grant.id}"),
+                meta = GrantCollectionItemMeta(),
+                links = GrantItemLinks(self = "$GRANTS_PATH/${grant.id}"),
             )
         },
-        links = JsonApiLinks.ResourceObjectLink(GRANTS_PATH),
         meta = JsonApiMeta(
             buildJsonObject {
                 put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
+                put("totalItems", this@toCollectionGrantResponse.totalItems)
+                put("totalPages", this@toCollectionGrantResponse.totalPages)
+                put("page", p.page)
+                put("pageSize", p.size)
             }
         )
     )
+}

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.currentTimeOslo
+import no.elhub.auth.features.common.dto.PaginatedCollectionResponse
+import no.elhub.auth.features.common.toPaginationLinks
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.documents.DOCUMENTS_PATH
 import no.elhub.auth.features.grants.AuthorizationGrant
@@ -19,7 +21,6 @@ import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToOne
 import no.elhub.devxp.jsonapi.model.JsonApiRelationships
 import no.elhub.devxp.jsonapi.response.JsonApiResponse
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationships
-
 @Serializable
 data class GrantResponseAttributes(
     val status: String,
@@ -44,9 +45,8 @@ typealias SingleGrantResponse = JsonApiResponse.SingleDocumentWithRelationships<
     GrantResponseRelationShips,
     >
 
-typealias CollectionGrantResponse = JsonApiResponse.CollectionDocumentWithRelationships<
-    GrantResponseAttributes,
-    GrantResponseRelationShips,
+typealias CollectionGrantResponse = PaginatedCollectionResponse<
+    JsonApiResponseResourceObjectWithRelationships<GrantResponseAttributes, GrantResponseRelationShips>
     >
 
 fun AuthorizationGrant.toSingleGrantResponse() =
@@ -185,15 +185,13 @@ fun Page<AuthorizationGrant>.toCollectionGrantResponse(): CollectionGrantRespons
                 ),
             )
         },
-        links = JsonApiLinks.ResourceObjectLink(GRANTS_PATH),
-        meta = JsonApiMeta(
-            buildJsonObject {
-                put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
-                put("totalItems", this@toCollectionGrantResponse.totalItems)
-                put("totalPages", this@toCollectionGrantResponse.totalPages)
-                put("page", p.page)
-                put("pageSize", p.size)
-            }
-        )
+        links = toPaginationLinks(GRANTS_PATH),
+        meta = buildJsonObject {
+            put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
+            put("totalItems", this@toCollectionGrantResponse.totalItems)
+            put("totalPages", this@toCollectionGrantResponse.totalPages)
+            put("page", p.page)
+            put("pageSize", p.size)
+        }
     )
 }

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
@@ -185,6 +185,7 @@ fun Page<AuthorizationGrant>.toCollectionGrantResponse(): CollectionGrantRespons
                 ),
             )
         },
+        links = JsonApiLinks.ResourceObjectLink(GRANTS_PATH),
         meta = JsonApiMeta(
             buildJsonObject {
                 put("createdAt", currentTimeOslo().toTimeZoneOffsetString())

--- a/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/dto/JsonApiGrantResponse.kt
@@ -17,11 +17,8 @@ import no.elhub.devxp.jsonapi.model.JsonApiRelationshipData
 import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToMany
 import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToOne
 import no.elhub.devxp.jsonapi.model.JsonApiRelationships
-import no.elhub.devxp.jsonapi.model.JsonApiResourceLinks
-import no.elhub.devxp.jsonapi.model.JsonApiResourceMeta
 import no.elhub.devxp.jsonapi.response.JsonApiResponse
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationships
-import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks
 
 @Serializable
 data class GrantResponseAttributes(
@@ -42,24 +39,14 @@ data class GrantResponseRelationShips(
     val scopes: JsonApiRelationshipToMany
 ) : JsonApiRelationships
 
-/** Per-item links for a grant in a collection response (just `self`). */
-@Serializable
-data class GrantItemLinks(val self: String) : JsonApiResourceLinks
-
-@Serializable
-@JvmInline
-value class GrantCollectionItemMeta(private val dummy: String = "") : JsonApiResourceMeta
-
 typealias SingleGrantResponse = JsonApiResponse.SingleDocumentWithRelationships<
     GrantResponseAttributes,
     GrantResponseRelationShips,
     >
 
-typealias CollectionGrantResponse = JsonApiResponse.CollectionDocumentWithRelationshipsAndMetaAndLinks<
+typealias CollectionGrantResponse = JsonApiResponse.CollectionDocumentWithRelationships<
     GrantResponseAttributes,
     GrantResponseRelationShips,
-    GrantCollectionItemMeta,
-    GrantItemLinks,
     >
 
 fun AuthorizationGrant.toSingleGrantResponse() =
@@ -142,7 +129,7 @@ fun Page<AuthorizationGrant>.toCollectionGrantResponse(): CollectionGrantRespons
 
     return CollectionGrantResponse(
         data = this.items.map { grant ->
-            JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks(
+            JsonApiResponseResourceObjectWithRelationships(
                 type = "AuthorizationGrant",
                 id = grant.id.toString(),
                 attributes = GrantResponseAttributes(
@@ -196,8 +183,6 @@ fun Page<AuthorizationGrant>.toCollectionGrantResponse(): CollectionGrantRespons
                         }
                     )
                 ),
-                meta = GrantCollectionItemMeta(),
-                links = GrantItemLinks(self = "$GRANTS_PATH/${grant.id}"),
             )
         },
         meta = JsonApiMeta(

--- a/src/main/kotlin/no/elhub/auth/features/grants/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/query/Handler.kt
@@ -2,6 +2,7 @@ package no.elhub.auth.features.grants.query
 
 import arrow.core.Either
 import arrow.core.raise.either
+import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.QueryError
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.grants.AuthorizationGrant
@@ -10,8 +11,8 @@ import no.elhub.auth.features.grants.common.GrantRepository
 class Handler(
     private val repo: GrantRepository,
 ) {
-    suspend operator fun invoke(query: Query): Either<QueryError, List<AuthorizationGrant>> = either {
-        repo.findAll(query.authorizedParty)
+    suspend operator fun invoke(query: Query): Either<QueryError, Page<AuthorizationGrant>> = either {
+        repo.findAll(query.authorizedParty, query.pagination)
             .mapLeft {
                 when (it) {
                     RepositoryReadError.NotFoundError -> QueryError.ResourceNotFoundError

--- a/src/main/kotlin/no/elhub/auth/features/grants/query/Query.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/query/Query.kt
@@ -1,7 +1,9 @@
 package no.elhub.auth.features.grants.query
 
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 
 data class Query(
-    val authorizedParty: AuthorizationParty
+    val authorizedParty: AuthorizationParty,
+    val pagination: Pagination = Pagination(),
 )

--- a/src/main/kotlin/no/elhub/auth/features/grants/query/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/query/Route.kt
@@ -5,6 +5,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
 import no.elhub.auth.features.common.toApiErrorResponse
@@ -22,9 +23,14 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
                 return@get
             }
 
-        val query = Query(authorizedParty = authorizedParty)
+        val pagination = Pagination.from(
+            pageParam = call.request.queryParameters["page[number]"],
+            sizeParam = call.request.queryParameters["page[size]"],
+        )
 
-        val grants = handler(query)
+        val query = Query(authorizedParty = authorizedParty, pagination = pagination)
+
+        val page = handler(query)
             .getOrElse { error ->
                 logger.error("Failed to get authorization grants: {}", error)
                 val (status, body) = error.toApiErrorResponse()
@@ -32,6 +38,6 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
                 return@get
             }
 
-        call.respond(HttpStatusCode.OK, grants.toCollectionGrantResponse())
+        call.respond(HttpStatusCode.OK, page.toCollectionGrantResponse())
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -9,6 +9,8 @@ import no.elhub.auth.features.common.RepositoryError
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.currentTimeUtc
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyRecord
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
@@ -55,7 +57,7 @@ sealed interface AcceptWithGrantError {
 
 interface RequestRepository {
     suspend fun find(requestId: UUID): Either<RepositoryReadError, AuthorizationRequest>
-    suspend fun findAllAndSortByCreatedAt(party: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationRequest>>
+    suspend fun findAllAndSortByCreatedAt(party: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationRequest>>
     suspend fun insert(
         request: AuthorizationRequest,
         scopes: List<CreateScopeData>
@@ -80,8 +82,8 @@ class ExposedRequestRepository(
     private val transactionContext: TransactionContext,
 ) : RequestRepository {
 
-    override suspend fun findAllAndSortByCreatedAt(party: AuthorizationParty): Either<RepositoryReadError, List<AuthorizationRequest>> =
-        transactionContext<RepositoryReadError, List<AuthorizationRequest>>(
+    override suspend fun findAllAndSortByCreatedAt(party: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationRequest>> =
+        transactionContext<RepositoryReadError, Page<AuthorizationRequest>>(
             "db_operations",
             "RequestRepository",
             "findAllAndSortByCreatedAt",
@@ -92,19 +94,25 @@ class ExposedRequestRepository(
                 .bind()
                 .id
 
+            val whereClause = { (AuthorizationRequestTable.requestedTo eq partyId) or (AuthorizationRequestTable.requestedBy eq partyId) }
+
+            val totalItems = AuthorizationRequestTable
+                .selectAll()
+                .where(whereClause)
+                .count()
+
             val requestRows = AuthorizationRequestTable
                 .selectAll()
-                .where {
-                    (AuthorizationRequestTable.requestedTo eq partyId) or (AuthorizationRequestTable.requestedBy eq partyId)
-                }
+                .where(whereClause)
                 .orderBy(AuthorizationRequestTable.createdAt to SortOrder.DESC)
+                .limit(pagination.size)
+                .offset(pagination.offset)
                 .toList()
 
-            if (requestRows.isEmpty()) return@transactionContext emptyList()
+            if (requestRows.isEmpty()) return@transactionContext Page(emptyList(), totalItems, pagination)
 
             val requestIds = requestRows.map { it[AuthorizationRequestTable.id].value }
 
-            // Batch-load all party records needed across all requests in a single query
             val allPartyIds = requestRows.flatMap {
                 listOfNotNull(
                     it[AuthorizationRequestTable.requestedBy],
@@ -118,7 +126,6 @@ class ExposedRequestRepository(
                 .where { AuthorizationPartyTable.id inList allPartyIds }
                 .associate { it[AuthorizationPartyTable.id].value to it.toAuthorizationParty() }
 
-            // Batch-load all properties for all requests in one query
             val propertiesByRequestId: Map<UUID, List<AuthorizationRequestProperty>> =
                 AuthorizationRequestPropertyTable
                     .selectAll()
@@ -128,15 +135,14 @@ class ExposedRequestRepository(
                         { it.toAuthorizationRequestProperty() }
                     )
 
-            requestRows.map { row ->
+            val items = requestRows.map { row ->
                 val requestedBy = partyMap[row[AuthorizationRequestTable.requestedBy]]
                     ?: raise(RepositoryReadError.UnexpectedError)
                 val requestedFrom = partyMap[row[AuthorizationRequestTable.requestedFrom]]
                     ?: raise(RepositoryReadError.UnexpectedError)
                 val requestedTo = partyMap[row[AuthorizationRequestTable.requestedTo]]
                     ?: raise(RepositoryReadError.UnexpectedError)
-                val approvedById = row[AuthorizationRequestTable.approvedBy]
-                val approvedBy = approvedById?.let { partyMap[it] ?: raise(RepositoryReadError.UnexpectedError) }
+                val approvedBy = row[AuthorizationRequestTable.approvedBy]?.let { partyMap[it] ?: raise(RepositoryReadError.UnexpectedError) }
                 val requestId = row[AuthorizationRequestTable.id].value
                 row.toAuthorizationRequest(
                     requestedBy = requestedBy,
@@ -146,6 +152,8 @@ class ExposedRequestRepository(
                     approvedBy = approvedBy,
                 )
             }
+
+            Page(items = items, totalItems = totalItems, pagination = pagination)
         }
 
     override suspend fun find(requestId: UUID): Either<RepositoryReadError, AuthorizationRequest> =

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -5,12 +5,12 @@ import arrow.core.raise.either
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.features.common.CreateScopeData
 import no.elhub.auth.features.common.PGEnum
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.RepositoryError
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.currentTimeUtc
-import no.elhub.auth.features.common.Page
-import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyRecord
 import no.elhub.auth.features.common.party.AuthorizationPartyTable

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/Handler.kt
@@ -2,6 +2,7 @@ package no.elhub.auth.features.requests.query
 
 import arrow.core.Either
 import arrow.core.raise.either
+import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.QueryError
 import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.common.GrantRepository
@@ -16,14 +17,14 @@ class Handler(
 
     private val logger = LoggerFactory.getLogger(Handler::class.java)
 
-    suspend operator fun invoke(query: Query): Either<QueryError, List<AuthorizationRequest>> = either {
-        val list = requestRepository.findAllAndSortByCreatedAt(query.authorizedParty)
+    suspend operator fun invoke(query: Query): Either<QueryError, Page<AuthorizationRequest>> = either {
+        val page = requestRepository.findAllAndSortByCreatedAt(query.authorizedParty, query.pagination)
             .mapLeft { QueryError.ResourceNotFoundError }
             .bind()
 
-        list.map { request ->
+        val enrichedItems = page.items.map { request ->
             if (request.approvedBy == null) {
-                return@map request
+                request
             } else {
                 // grant can only exist if approvedBy is set
                 val grant = grantRepository.findBySource(
@@ -37,5 +38,7 @@ class Handler(
                 grant?.let { request.copy(grantId = it.id) } ?: request
             }
         }
+
+        page.copy(items = enrichedItems)
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/Handler.kt
@@ -34,18 +34,18 @@ class Handler(
             QueryError.IOError
         }.bind()
 
-        val enrichedItems = page.items.map { request ->
-            if (request.approvedBy == null) {
-                request
-            } else {
-                val grant = grantsBySourceId[request.id]
-                if (grant == null) {
-                    logger.error("approvedBy is present but grant not found for request ${request.id}")
+        page.copy(
+            items = page.items.map { request ->
+                if (request.approvedBy == null) {
+                    request
+                } else {
+                    val grant = grantsBySourceId[request.id]
+                    if (grant == null) {
+                        logger.error("approvedBy is present but grant not found for request ${request.id}")
+                    }
+                    grant?.let { request.copy(grantId = it.id) } ?: request
                 }
-                grant?.let { request.copy(grantId = it.id) } ?: request
             }
-        }
-
-        page.copy(items = enrichedItems)
+        )
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/Query.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/Query.kt
@@ -1,7 +1,9 @@
 package no.elhub.auth.features.requests.query
 
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 
 data class Query(
-    val authorizedParty: AuthorizationParty
+    val authorizedParty: AuthorizationParty,
+    val pagination: Pagination = Pagination(),
 )

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/Route.kt
@@ -5,6 +5,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
 import no.elhub.auth.features.common.toApiErrorResponse
@@ -22,15 +23,20 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
                 return@get
             }
 
-        val query = Query(authorizedParty = authorizedParty)
+        val pagination = Pagination.from(
+            pageParam = call.request.queryParameters["page[number]"],
+            sizeParam = call.request.queryParameters["page[size]"],
+        )
 
-        val requests = handler(query)
+        val query = Query(authorizedParty = authorizedParty, pagination = pagination)
+
+        val page = handler(query)
             .getOrElse { error ->
                 logger.error("Failed to get authorization requests: {}", error)
                 val (status, body) = error.toApiErrorResponse()
                 call.respond(status, body)
                 return@get
             }
-        call.respond(HttpStatusCode.OK, requests.toGetCollectionResponse())
+        call.respond(HttpStatusCode.OK, page.toGetCollectionResponse())
     }
 }

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/dto/JsonApiGetCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/dto/JsonApiGetCollectionResponse.kt
@@ -2,6 +2,7 @@ package no.elhub.auth.features.requests.query.dto
 
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.currentTimeOslo
 import no.elhub.auth.features.common.dto.JsonApiResourceMetaMap
 import no.elhub.auth.features.common.party.dto.toJsonApiRelationship
@@ -26,9 +27,11 @@ typealias GetRequestCollectionResponse = JsonApiResponse.CollectionDocumentWithR
     AuthorizationRequestResponseLinks
     >
 
-fun List<AuthorizationRequest>.toGetCollectionResponse() =
-    GetRequestCollectionResponse(
-        data = this.map { request ->
+fun Page<AuthorizationRequest>.toGetCollectionResponse(): GetRequestCollectionResponse {
+    val p = this.pagination
+
+    return JsonApiResponse.CollectionDocumentWithRelationshipsAndMetaAndLinks(
+        data = this.items.map { request ->
             JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks(
                 id = request.id.toString(),
                 type = "AuthorizationRequest",
@@ -64,14 +67,18 @@ fun List<AuthorizationRequest>.toGetCollectionResponse() =
                     }
                 ),
                 links = AuthorizationRequestResponseLinks(
-                    self = "${REQUESTS_PATH}/${request.id}",
+                    self = "$REQUESTS_PATH/${request.id}",
                 )
             )
         },
-        links = JsonApiLinks.ResourceObjectLink(REQUESTS_PATH),
         meta = JsonApiMeta(
             buildJsonObject {
                 put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
+                put("totalItems", this@toGetCollectionResponse.totalItems)
+                put("totalPages", this@toGetCollectionResponse.totalPages)
+                put("page", p.page)
+                put("pageSize", p.size)
             }
         )
     )
+}

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/dto/JsonApiGetCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/dto/JsonApiGetCollectionResponse.kt
@@ -71,6 +71,7 @@ fun Page<AuthorizationRequest>.toGetCollectionResponse(): GetRequestCollectionRe
                 )
             )
         },
+        links = JsonApiLinks.ResourceObjectLink(REQUESTS_PATH),
         meta = JsonApiMeta(
             buildJsonObject {
                 put("createdAt", currentTimeOslo().toTimeZoneOffsetString())

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/dto/JsonApiGetCollectionResponse.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/dto/JsonApiGetCollectionResponse.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.json.put
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.currentTimeOslo
 import no.elhub.auth.features.common.dto.JsonApiResourceMetaMap
+import no.elhub.auth.features.common.dto.PaginatedCollectionResponse
 import no.elhub.auth.features.common.party.dto.toJsonApiRelationship
+import no.elhub.auth.features.common.toPaginationLinks
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.grants.GRANTS_PATH
 import no.elhub.auth.features.requests.AuthorizationRequest
@@ -14,23 +16,23 @@ import no.elhub.auth.features.requests.common.dto.AuthorizationRequestResponseAt
 import no.elhub.auth.features.requests.common.dto.AuthorizationRequestResponseLinks
 import no.elhub.auth.features.requests.common.dto.AuthorizationRequestResponseRelationships
 import no.elhub.devxp.jsonapi.model.JsonApiLinks
-import no.elhub.devxp.jsonapi.model.JsonApiMeta
 import no.elhub.devxp.jsonapi.model.JsonApiRelationshipData
 import no.elhub.devxp.jsonapi.model.JsonApiRelationshipToOne
-import no.elhub.devxp.jsonapi.response.JsonApiResponse
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks
 
-typealias GetRequestCollectionResponse = JsonApiResponse.CollectionDocumentWithRelationshipsAndMetaAndLinks<
-    AuthorizationRequestResponseAttributes,
-    AuthorizationRequestResponseRelationships,
-    JsonApiResourceMetaMap,
-    AuthorizationRequestResponseLinks
+typealias GetRequestCollectionResponse = PaginatedCollectionResponse<
+    JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks<
+        AuthorizationRequestResponseAttributes,
+        AuthorizationRequestResponseRelationships,
+        JsonApiResourceMetaMap,
+        AuthorizationRequestResponseLinks
+        >
     >
 
 fun Page<AuthorizationRequest>.toGetCollectionResponse(): GetRequestCollectionResponse {
     val p = this.pagination
 
-    return JsonApiResponse.CollectionDocumentWithRelationshipsAndMetaAndLinks(
+    return GetRequestCollectionResponse(
         data = this.items.map { request ->
             JsonApiResponseResourceObjectWithRelationshipsAndMetaAndLinks(
                 id = request.id.toString(),
@@ -71,15 +73,13 @@ fun Page<AuthorizationRequest>.toGetCollectionResponse(): GetRequestCollectionRe
                 )
             )
         },
-        links = JsonApiLinks.ResourceObjectLink(REQUESTS_PATH),
-        meta = JsonApiMeta(
-            buildJsonObject {
-                put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
-                put("totalItems", this@toGetCollectionResponse.totalItems)
-                put("totalPages", this@toGetCollectionResponse.totalPages)
-                put("page", p.page)
-                put("pageSize", p.size)
-            }
-        )
+        links = toPaginationLinks(REQUESTS_PATH),
+        meta = buildJsonObject {
+            put("createdAt", currentTimeOslo().toTimeZoneOffsetString())
+            put("totalItems", this@toGetCollectionResponse.totalItems)
+            put("totalPages", this@toGetCollectionResponse.totalPages)
+            put("page", p.page)
+            put("pageSize", p.size)
+        }
     )
 }

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -59,7 +59,7 @@ paths:
         - name: page[size]
           in: query
           required: false
-          description: Number of items per page. Defaults to 20, maximum 100.
+          description: Number of items per page. Defaults to 30, maximum 100.
           schema:
             type: integer
             minimum: 1
@@ -261,7 +261,7 @@ paths:
         - name: page[size]
           in: query
           required: false
-          description: Number of items per page. Defaults to 20, maximum 100.
+          description: Number of items per page. Defaults to 30, maximum 100.
           schema:
             type: integer
             minimum: 1
@@ -430,7 +430,7 @@ paths:
         - name: page[size]
           in: query
           required: false
-          description: Number of items per page. Defaults to 20, maximum 100.
+          description: Number of items per page. Defaults to 30, maximum 100.
           schema:
             type: integer
             minimum: 1

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -435,7 +435,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 20
+            default: 30
       responses:
         '200':
           description: A list of authorization requests.

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -48,6 +48,23 @@ paths:
         - $ref: '#/components/parameters/AuthorizationMaskinporten'
         - $ref: '#/components/parameters/SenderGlnRequired'
         - $ref: '#/components/parameters/OnBehalfOfGlnOptional'
+        - name: page[number]
+          in: query
+          required: false
+          description: Zero-based page number. Defaults to 0.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: page[size]
+          in: query
+          required: false
+          description: Number of items per page. Defaults to 20, maximum 100.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         '200':
           description: A list of authorization document objects.
@@ -226,12 +243,30 @@ paths:
       summary: List authorization grants
       description: >
         Retrieve a list of authorization grants available to the caller. The result is constrained
-        by the caller's token and GLN context.
+        by the caller's token and GLN context. Results are returned ordered by createdAt DESC
+        (newest first) and support offset-based pagination.
       parameters:
         - $ref: '#/components/parameters/UserAgent'
         - $ref: '#/components/parameters/AuthorizationMaskinportenOrEndUser'
         - $ref: '#/components/parameters/SenderGlnOptional'
         - $ref: '#/components/parameters/OnBehalfOfGlnOptional'
+        - name: page[number]
+          in: query
+          required: false
+          description: Zero-based page number. Defaults to 0.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: page[size]
+          in: query
+          required: false
+          description: Number of items per page. Defaults to 20, maximum 100.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         '200':
           description: A list of authorization grants.
@@ -377,12 +412,30 @@ paths:
       summary: List authorization requests
       description: >
         Retrieve a list of authorization requests. The result is constrained by the caller's
-        token and, where applicable, GLN context. Results are returned ordered by createdAt DESC (newest first).
+        token and, where applicable, GLN context. Results are returned ordered by createdAt DESC
+        (newest first) and support offset-based pagination.
       parameters:
         - $ref: '#/components/parameters/UserAgent'
         - $ref: '#/components/parameters/AuthorizationMaskinportenOrEndUser'
         - $ref: '#/components/parameters/SenderGlnOptional'
         - $ref: '#/components/parameters/OnBehalfOfGlnOptional'
+        - name: page[number]
+          in: query
+          required: false
+          description: Zero-based page number. Defaults to 0.
+          schema:
+            type: integer
+            minimum: 0
+            default: 0
+        - name: page[size]
+          in: query
+          required: false
+          description: Number of items per page. Defaults to 20, maximum 100.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
       responses:
         '200':
           description: A list of authorization requests.

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -64,7 +64,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 20
+            default: 30
       responses:
         '200':
           description: A list of authorization document objects.

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -266,7 +266,7 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
-            default: 20
+            default: 30
       responses:
         '200':
           description: A list of authorization grants.

--- a/src/main/resources/static/schemas/documents/authorization-document-collection.schema.json
+++ b/src/main/resources/static/schemas/documents/authorization-document-collection.schema.json
@@ -22,7 +22,31 @@
       ]
     },
     "meta": {
-      "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"
+      "allOf": [
+        { "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta" },
+        {
+          "type": "object",
+          "properties": {
+            "totalItems": {
+              "type": "integer",
+              "description": "Total number of items matching the query."
+            },
+            "totalPages": {
+              "type": "integer",
+              "description": "Total number of pages."
+            },
+            "page": {
+              "type": "integer",
+              "description": "Current zero-based page number."
+            },
+            "pageSize": {
+              "type": "integer",
+              "description": "Number of items per page."
+            }
+          },
+          "required": ["totalItems", "totalPages", "page", "pageSize"]
+        }
+      ]
     }
   },
   "required": [

--- a/src/main/resources/static/schemas/documents/authorization-document-collection.schema.json
+++ b/src/main/resources/static/schemas/documents/authorization-document-collection.schema.json
@@ -23,7 +23,9 @@
     },
     "meta": {
       "allOf": [
-        { "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta" },
+        {
+          "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"
+        },
         {
           "type": "object",
           "properties": {
@@ -44,14 +46,15 @@
               "description": "Number of items per page."
             }
           },
-          "required": ["totalItems", "totalPages", "page", "pageSize"]
+          "required": [
+            "totalItems",
+            "totalPages",
+            "page",
+            "pageSize"
+          ]
         }
       ]
     }
   },
-  "required": [
-    "data",
-    "links",
-    "meta"
-  ]
+  "required": ["data", "links", "meta"]
 }

--- a/src/main/resources/static/schemas/grants/authorization-grant-collection.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-grant-collection.schema.json
@@ -22,7 +22,31 @@
       ]
     },
     "meta": {
-      "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"
+      "allOf": [
+        { "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta" },
+        {
+          "type": "object",
+          "properties": {
+            "totalItems": {
+              "type": "integer",
+              "description": "Total number of items matching the query."
+            },
+            "totalPages": {
+              "type": "integer",
+              "description": "Total number of pages."
+            },
+            "page": {
+              "type": "integer",
+              "description": "Current zero-based page number."
+            },
+            "pageSize": {
+              "type": "integer",
+              "description": "Number of items per page."
+            }
+          },
+          "required": ["totalItems", "totalPages", "page", "pageSize"]
+        }
+      ]
     }
   },
   "required": [

--- a/src/main/resources/static/schemas/grants/authorization-grant-collection.schema.json
+++ b/src/main/resources/static/schemas/grants/authorization-grant-collection.schema.json
@@ -23,7 +23,9 @@
     },
     "meta": {
       "allOf": [
-        { "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta" },
+        {
+          "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"
+        },
         {
           "type": "object",
           "properties": {
@@ -44,14 +46,15 @@
               "description": "Number of items per page."
             }
           },
-          "required": ["totalItems", "totalPages", "page", "pageSize"]
+          "required": [
+            "totalItems",
+            "totalPages",
+            "page",
+            "pageSize"
+          ]
         }
       ]
     }
   },
-  "required": [
-    "data",
-    "links",
-    "meta"
-  ]
+  "required": ["data", "links", "meta"]
 }

--- a/src/main/resources/static/schemas/json-api-framework.schema.json
+++ b/src/main/resources/static/schemas/json-api-framework.schema.json
@@ -47,9 +47,7 @@
           "type": "string",
           "format": "date-time",
           "description": "The date and time when the document was created.",
-          "examples": [
-            "2025-12-17T12:51:57+01:00"
-          ]
+          "examples": ["2025-12-17T12:51:57+01:00"]
         }
       }
     },
@@ -57,15 +55,11 @@
       "anyOf": [
         {
           "type": "object",
-          "required": [
-            "meta"
-          ]
+          "required": ["meta"]
         },
         {
           "type": "object",
-          "required": [
-            "data"
-          ]
+          "required": ["data"]
         }
       ]
     }

--- a/src/main/resources/static/schemas/json-api-framework.schema.json
+++ b/src/main/resources/static/schemas/json-api-framework.schema.json
@@ -13,14 +13,31 @@
       "pattern": "^[a-zA-Z0-9]{1}(?:[-\\w]*[a-zA-Z0-9])?$"
     },
     "topLevelLinks": {
-      "description": "The top-level links object **may** contain the following members: self, related, pagination links. Currently, only self is defined.",
+      "description": "The top-level links object for a collection response, including self and pagination links.",
       "type": "object",
       "properties": {
         "self": {
           "description": "The link that generated the current JSON document.",
           "$ref": "#/$defs/linkUrl"
+        },
+        "first": {
+          "description": "The link to the first page of data.",
+          "$ref": "#/$defs/linkUrl"
+        },
+        "last": {
+          "description": "The link to the last page of data.",
+          "$ref": "#/$defs/linkUrl"
+        },
+        "prev": {
+          "description": "The link to the previous page of data. Absent when on the first page.",
+          "$ref": "#/$defs/linkUrl"
+        },
+        "next": {
+          "description": "The link to the next page of data. Absent when on the last page.",
+          "$ref": "#/$defs/linkUrl"
         }
-      }
+      },
+      "required": ["self", "first", "last"]
     },
     "topLevelMeta": {
       "description": "Meta-information for the JSON document.",

--- a/src/main/resources/static/schemas/requests/authorization-request-collection.schema.json
+++ b/src/main/resources/static/schemas/requests/authorization-request-collection.schema.json
@@ -23,7 +23,9 @@
     },
     "meta": {
       "allOf": [
-        { "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta" },
+        {
+          "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"
+        },
         {
           "type": "object",
           "properties": {
@@ -44,7 +46,12 @@
               "description": "Number of items per page."
             }
           },
-          "required": ["totalItems", "totalPages", "page", "pageSize"]
+          "required": [
+            "totalItems",
+            "totalPages",
+            "page",
+            "pageSize"
+          ]
         }
       ]
     }

--- a/src/main/resources/static/schemas/requests/authorization-request-collection.schema.json
+++ b/src/main/resources/static/schemas/requests/authorization-request-collection.schema.json
@@ -22,7 +22,31 @@
       ]
     },
     "meta": {
-      "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta"
+      "allOf": [
+        { "$ref": "../json-api-framework.schema.json#/$defs/topLevelMeta" },
+        {
+          "type": "object",
+          "properties": {
+            "totalItems": {
+              "type": "integer",
+              "description": "Total number of items matching the query."
+            },
+            "totalPages": {
+              "type": "integer",
+              "description": "Total number of pages."
+            },
+            "page": {
+              "type": "integer",
+              "description": "Current zero-based page number."
+            },
+            "pageSize": {
+              "type": "integer",
+              "description": "Number of items per page."
+            }
+          },
+          "required": ["totalItems", "totalPages", "page", "pageSize"]
+        }
+      ]
     }
   },
   "required": ["data", "links", "meta"],

--- a/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
@@ -177,6 +177,77 @@ class ExposedDocumentRepositoryTest :
             }
         }
 
+        context("pagination") {
+            fun makeDocument(requestedBy: AuthorizationParty) = AuthorizationDocument(
+                id = UUID.randomUUID(),
+                file = byteArrayOf(),
+                type = AuthorizationDocument.Type.ChangeOfBalanceSupplierForPerson,
+                status = AuthorizationDocument.Status.Pending,
+                requestedBy = requestedBy,
+                requestedFrom = AuthorizationParty(type = PartyType.Person, id = "from-p"),
+                requestedTo = AuthorizationParty(type = PartyType.Person, id = "to-p"),
+                properties = emptyList(),
+                validTo = currentTimeUtc().plusDays(1),
+                createdAt = currentTimeUtc(),
+                updatedAt = currentTimeUtc()
+            )
+
+            test("returns correct page size and totalItems") {
+                val party = AuthorizationParty(type = PartyType.Organization, id = "paginate-party-1")
+                repeat(5) { repository.insert(makeDocument(party), listOf()) }
+
+                val page = repository.findAll(party, Pagination(page = 0, size = 2))
+                    .getOrElse { fail("findAll failed") }
+
+                page.items.size shouldBe 2
+                page.totalItems shouldBe 5
+                page.totalPages shouldBe 3
+            }
+
+            test("returns next page when page=1") {
+                val party = AuthorizationParty(type = PartyType.Organization, id = "paginate-party-2")
+                repeat(5) { repository.insert(makeDocument(party), listOf()) }
+
+                val page = repository.findAll(party, Pagination(page = 1, size = 2))
+                    .getOrElse { fail("findAll failed") }
+
+                page.items.size shouldBe 2
+                page.totalItems shouldBe 5
+            }
+
+            test("returns partial last page") {
+                val party = AuthorizationParty(type = PartyType.Organization, id = "paginate-party-3")
+                repeat(5) { repository.insert(makeDocument(party), listOf()) }
+
+                val page = repository.findAll(party, Pagination(page = 2, size = 2))
+                    .getOrElse { fail("findAll failed") }
+
+                page.items.size shouldBe 1
+                page.totalItems shouldBe 5
+            }
+
+            test("returns empty items but correct totalItems when page is beyond data") {
+                val party = AuthorizationParty(type = PartyType.Organization, id = "paginate-party-4")
+                repeat(5) { repository.insert(makeDocument(party), listOf()) }
+
+                val page = repository.findAll(party, Pagination(page = 10, size = 2))
+                    .getOrElse { fail("findAll failed") }
+
+                page.items shouldBe emptyList()
+                page.totalItems shouldBe 5
+            }
+
+            test("pages do not overlap") {
+                val party = AuthorizationParty(type = PartyType.Organization, id = "paginate-party-5")
+                repeat(5) { repository.insert(makeDocument(party), listOf()) }
+
+                val page0 = repository.findAll(party, Pagination(page = 0, size = 2)).getOrElse { fail("page 0") }
+                val page1 = repository.findAll(party, Pagination(page = 1, size = 2)).getOrElse { fail("page 1") }
+
+                (page0.items.map { it.id }.toSet() intersect page1.items.map { it.id }.toSet()) shouldBe emptySet()
+            }
+        }
+
         context("confirmWithGrant") {
             test("atomically confirms document and creates grant with properties") {
                 val requestedBy = AuthorizationParty(type = PartyType.Person, id = "conf-req-by")

--- a/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
@@ -17,6 +17,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.config.withTransaction
 import no.elhub.auth.features.common.CreateScopeData
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.PostgresTestContainer
 import no.elhub.auth.features.common.PostgresTestContainerExtension
 import no.elhub.auth.features.common.RepositoryReadError
@@ -166,9 +167,9 @@ class ExposedDocumentRepositoryTest :
                 repository.insert(otherDocument, listOf())
 
                 val documents =
-                    repository.findAll(AuthorizationParty(matchingRequestedBy.id, PartyType.Organization))
+                    repository.findAll(AuthorizationParty(matchingRequestedBy.id, PartyType.Organization), Pagination())
                         .getOrElse { error -> fail("Failed to fetch documents: $error") }
-                val documentIds = documents.map { it.id }
+                val documentIds = documents.items.map { it.id }
 
                 documentIds.shouldHaveSize(1)
                 documentIds shouldContain matchingDocument.id

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
@@ -3,8 +3,8 @@ package no.elhub.auth.features.documents.query
 import arrow.core.Either
 import arrow.core.right
 import io.kotest.assertions.arrow.core.shouldBeRight
-import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
@@ -3,6 +3,7 @@ package no.elhub.auth.features.documents.query
 import arrow.core.Either
 import arrow.core.right
 import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.matchers.shouldBe
 import io.kotest.core.spec.style.FunSpec
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -87,6 +88,25 @@ class HandlerTest : FunSpec({
                 findBySourceIds(AuthorizationGrant.SourceType.Document, any())
             } returns result
         }
+
+    test("passes pagination from query to repository and preserves page metadata") {
+        val pagination = Pagination(page = 1, size = 1)
+        val documentRepo = documentRepoReturning(Page(listOf(firstDocument), 2L, pagination).right())
+        val handler = Handler(documentRepo, grantRepoReturning(emptyMap<UUID, AuthorizationGrant>().right()))
+
+        val response = handler(
+            Query(
+                authorizedParty = requestedBy,
+                pagination = pagination,
+            )
+        )
+
+        coVerify(exactly = 1) { documentRepo.findAll(requestedBy, pagination) }
+        val page = response.shouldBeRight()
+        page.pagination shouldBe pagination
+        page.totalItems shouldBe 2L
+        page.totalPages shouldBe 2
+    }
 
     test("returns documents with grant ids resolved for authorized party") {
         val pagination = Pagination()

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/HandlerTest.kt
@@ -9,6 +9,8 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.currentTimeUtc
 import no.elhub.auth.features.common.party.AuthorizationParty
@@ -74,9 +76,9 @@ class HandlerTest : FunSpec({
         validTo = grantValidTo.toTimeZoneOffsetDateTimeAtStartOfDay()
     )
 
-    fun documentRepoReturning(result: Either<RepositoryReadError, List<AuthorizationDocument>>): DocumentRepository =
+    fun documentRepoReturning(result: Either<RepositoryReadError, Page<AuthorizationDocument>>): DocumentRepository =
         mockk<DocumentRepository> {
-            coEvery { findAll(any()) } returns result
+            coEvery { findAll(any(), any()) } returns result
         }
 
     fun grantRepoReturning(
@@ -95,20 +97,26 @@ class HandlerTest : FunSpec({
     test("returns documents with grant ids resolved for authorized party") {
         val noGrant: Either<RepositoryReadError, AuthorizationGrant?> = null.right()
 
-        val documentRepo = documentRepoReturning(listOf(firstDocument, secondDocument).right())
+        val pagination = Pagination()
+        val documentRepo = documentRepoReturning(Page(listOf(firstDocument, secondDocument), 2L, pagination).right())
         val handler = Handler(documentRepo, grantRepoReturning(grant.right(), noGrant))
 
         val response = handler(
             Query(
-                authorizedParty = requestedBy
+                authorizedParty = requestedBy,
+                pagination = pagination,
             )
         )
 
-        coVerify(exactly = 1) { documentRepo.findAll(requestedBy) }
+        coVerify(exactly = 1) { documentRepo.findAll(requestedBy, pagination) }
         response.shouldBeRight(
-            listOf(
-                firstDocument.copy(grantId = grant.id),
-                secondDocument.copy(grantId = null)
+            Page(
+                items = listOf(
+                    firstDocument.copy(grantId = grant.id),
+                    secondDocument.copy(grantId = null)
+                ),
+                totalItems = 2L,
+                pagination = pagination,
             )
         )
     }

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
@@ -12,6 +12,8 @@ import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.QueryError
 import no.elhub.auth.features.common.auth.AuthError
 import no.elhub.auth.features.common.auth.AuthorizationProvider
@@ -84,7 +86,7 @@ class RouteTest : FunSpec({
 
     test("GET / returns 200 when authorized as person and handler succeeds") {
         coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
-        coEvery { handler.invoke(any()) } returns documents.right()
+        coEvery { handler.invoke(any()) } returns Page(documents, documents.size.toLong(), Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             var response = client.get("/")
@@ -95,7 +97,7 @@ class RouteTest : FunSpec({
 
     test("GET / returns 200 when authorized as org and handler succeeds") {
         coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedOrg.right()
-        coEvery { handler.invoke(any()) } returns documents.right()
+        coEvery { handler.invoke(any()) } returns Page(documents, documents.size.toLong(), Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             var response = client.get("/")
@@ -105,7 +107,7 @@ class RouteTest : FunSpec({
     }
     test("GET / returns 403 'Forbidden' when authorization fails with AccessDenied error") {
         coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.AccessDenied.left()
-        coEvery { handler.invoke(any()) } returns documents.right()
+        coEvery { handler.invoke(any()) } returns Page(documents, documents.size.toLong(), Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             validateForbiddenResponse(client.get("/"))

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
@@ -12,6 +12,9 @@ import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.QueryError
@@ -122,6 +125,33 @@ class RouteTest : FunSpec({
             val response = client.get("/")
             validateInternalServerErrorResponse(response)
             coVerify(exactly = 1) { handler.invoke(any()) }
+        }
+    }
+
+    test("GET with page params passes correct Pagination to handler") {
+        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationDocument>(), 0L, Pagination(page = 2, size = 5)).right()
+        testApplication {
+            setupAppWith { route(handler, authProvider) }
+            client.get("/?page[number]=2&page[size]=5")
+        }
+        coVerify(exactly = 1) { handler.invoke(match { it.pagination == Pagination(page = 2, size = 5) }) }
+    }
+
+    test("GET response meta contains pagination fields") {
+        val pagination = Pagination(page = 0, size = 10)
+        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationDocument>(), 4L, pagination).right()
+        testApplication {
+            setupAppWith { route(handler, authProvider) }
+            val response = client.get("/")
+            response.status shouldBe HttpStatusCode.OK
+            val body = response.body<JsonObject>()
+            val meta = body["meta"]!!.jsonObject
+            meta["totalItems"]!!.jsonPrimitive.content shouldBe "4"
+            meta["totalPages"]!!.jsonPrimitive.content shouldBe "1"
+            meta["page"]!!.jsonPrimitive.content shouldBe "0"
+            meta["pageSize"]!!.jsonPrimitive.content shouldBe "10"
         }
     }
 })

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
@@ -25,6 +25,7 @@ import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.common.toTimeZoneOffsetString
 import no.elhub.auth.features.documents.AuthorizationDocument
+import no.elhub.auth.features.documents.DOCUMENTS_PATH
 import no.elhub.auth.features.documents.common.AuthorizationDocumentProperty
 import no.elhub.auth.features.documents.query.dto.GetDocumentCollectionResponse
 import no.elhub.auth.setupAppWith
@@ -138,7 +139,7 @@ class RouteTest : FunSpec({
         coVerify(exactly = 1) { handler.invoke(match { it.pagination == Pagination(page = 2, size = 5) }) }
     }
 
-    test("GET response meta contains pagination fields") {
+    test("GET response meta and links contain correct pagination fields") {
         val pagination = Pagination(page = 0, size = 10)
         coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationDocument>(), 4L, pagination).right()
@@ -152,6 +153,29 @@ class RouteTest : FunSpec({
             meta["totalPages"]!!.jsonPrimitive.content shouldBe "1"
             meta["page"]!!.jsonPrimitive.content shouldBe "0"
             meta["pageSize"]!!.jsonPrimitive.content shouldBe "10"
+            val links = body["links"]!!.jsonObject
+            links["self"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=0&page[size]=10"
+            links["first"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=0&page[size]=10"
+            links["last"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=0&page[size]=10"
+            links["prev"] shouldBe null
+            links["next"] shouldBe null
+        }
+    }
+
+    test("GET links on a middle page contain prev and next") {
+        val pagination = Pagination(page = 1, size = 5)
+        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationDocument>(), 15L, pagination).right()
+        testApplication {
+            setupAppWith { route(handler, authProvider) }
+            val response = client.get("/")
+            response.status shouldBe HttpStatusCode.OK
+            val links = response.body<JsonObject>()["links"]!!.jsonObject
+            links["self"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=1&page[size]=5"
+            links["first"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=0&page[size]=5"
+            links["last"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=2&page[size]=5"
+            links["prev"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=0&page[size]=5"
+            links["next"]!!.jsonPrimitive.content shouldBe "$DOCUMENTS_PATH?page[number]=2&page[size]=5"
         }
     }
 })

--- a/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
@@ -15,6 +15,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.jsonPrimitive
 import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
@@ -601,6 +602,17 @@ class AuthorizationGrantRouteTest : FunSpec({
                                 }
                             }
                         }
+                    }
+                    responseJson.meta["totalItems"]!!.jsonPrimitive.content shouldBe "5"
+                    responseJson.meta["totalPages"]!!.jsonPrimitive.content shouldBe "1"
+                    responseJson.meta["page"]!!.jsonPrimitive.content shouldBe "0"
+                    responseJson.meta["pageSize"]!!.jsonPrimitive.content shouldBe "30"
+                    responseJson.links.apply {
+                        self shouldBe "$GRANTS_PATH?page[number]=0&page[size]=30"
+                        first shouldBe "$GRANTS_PATH?page[number]=0&page[size]=30"
+                        last shouldBe "$GRANTS_PATH?page[number]=0&page[size]=30"
+                        prev shouldBe null
+                        next shouldBe null
                     }
                 }
 

--- a/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
@@ -509,8 +509,9 @@ class AuthorizationGrantRouteTest : FunSpec({
                     val responseJson: CollectionGrantResponse = response.body()
                     responseJson.data.apply {
                         size shouldBe 5
-                        this[0].apply {
-                            id.shouldNotBeNull()
+
+                        val activeGrant = first { it.id == "123e4567-e89b-12d3-a456-426614174000" }
+                        activeGrant.apply {
                             type shouldBe "AuthorizationGrant"
                             attributes.shouldNotBeNull()
                             attributes!!.apply {
@@ -559,8 +560,9 @@ class AuthorizationGrantRouteTest : FunSpec({
                                 }
                             }
                         }
-                        this[1].apply {
-                            id.shouldNotBeNull()
+
+                        val revokedGrant = first { it.id == "a8f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a" }
+                        revokedGrant.apply {
                             type shouldBe "AuthorizationGrant"
                             attributes.shouldNotBeNull()
                             attributes!!.apply {

--- a/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/AuthorizationGrantRouteTest.kt
@@ -15,10 +15,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.json.jsonPrimitive
 import io.ktor.server.config.MapApplicationConfig
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.jsonPrimitive
 import no.elhub.auth.features.common.AuthPersonsTestContainer
 import no.elhub.auth.features.common.AuthPersonsTestContainerExtension
 import no.elhub.auth.features.common.PdpTestContainerExtension

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -175,6 +175,58 @@ class ExposedGrantRepositoryTest : FunSpec({
         result.size shouldBe 0
     }
 
+    test("findAll returns correct page size and totalItems") {
+        insertTestData()
+        val party = AuthorizationParty(type = PartyType.OrganizationEntity, id = "0107000000021")
+
+        val page = grantRepo.findAll(party, Pagination(page = 0, size = 2)).getOrElse { fail("findAll failed") }
+
+        page.items.size shouldBe 2
+        page.totalItems shouldBe 5
+        page.totalPages shouldBe 3
+    }
+
+    test("findAll returns next page when page=1") {
+        insertTestData()
+        val party = AuthorizationParty(type = PartyType.OrganizationEntity, id = "0107000000021")
+
+        val page = grantRepo.findAll(party, Pagination(page = 1, size = 2)).getOrElse { fail("findAll failed") }
+
+        page.items.size shouldBe 2
+        page.totalItems shouldBe 5
+    }
+
+    test("findAll returns partial last page") {
+        insertTestData()
+        val party = AuthorizationParty(type = PartyType.OrganizationEntity, id = "0107000000021")
+
+        val page = grantRepo.findAll(party, Pagination(page = 2, size = 2)).getOrElse { fail("findAll failed") }
+
+        page.items.size shouldBe 1
+        page.totalItems shouldBe 5
+    }
+
+    test("findAll returns empty items but correct totalItems when page is beyond data") {
+        insertTestData()
+        val party = AuthorizationParty(type = PartyType.OrganizationEntity, id = "0107000000021")
+
+        val page =
+            grantRepo.findAll(party, Pagination(page = 10, size = 2)).getOrElse { fail("findAll failed") }
+
+        page.items shouldBe emptyList()
+        page.totalItems shouldBe 5
+    }
+
+    test("findAll pages do not overlap") {
+        insertTestData()
+        val party = AuthorizationParty(type = PartyType.OrganizationEntity, id = "0107000000021")
+
+        val page0 = grantRepo.findAll(party, Pagination(page = 0, size = 2)).getOrElse { fail("page 0 failed") }
+        val page1 = grantRepo.findAll(party, Pagination(page = 1, size = 2)).getOrElse { fail("page 1 failed") }
+
+        (page0.items.map { it.id }.toSet() intersect page1.items.map { it.id }.toSet()) shouldBe emptySet()
+    }
+
     test("findScopes returns correct number of scopes given grantId") {
         insertTestData()
         val scopes = grantRepo.findScopes(grantId = UUID.fromString("b7f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a"))

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -15,6 +15,7 @@ import no.elhub.auth.config.withTransaction
 import no.elhub.auth.features.common.PostgresTestContainer
 import no.elhub.auth.features.common.PostgresTestContainerExtension
 import no.elhub.auth.features.common.RepositoryReadError
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
 import no.elhub.auth.features.common.party.ExposedPartyRepository
@@ -124,15 +125,15 @@ class ExposedGrantRepositoryTest : FunSpec({
         val partyWithGrants = AuthorizationParty(type = PartyType.OrganizationEntity, id = "0107000000021")
         val partyWithoutGrants = AuthorizationParty(type = PartyType.Person, id = "666")
 
-        val resultForPartyWithGrants = grantRepo.findAll(partyWithGrants).getOrElse {
+        val resultForPartyWithGrants = grantRepo.findAll(partyWithGrants, Pagination()).getOrElse {
             fail("Failed to read grants for party with grants")
         }
-        resultForPartyWithGrants.size shouldBe 5
+        resultForPartyWithGrants.items.size shouldBe 5
 
-        val resultForPartyWithoutGrants = grantRepo.findAll(partyWithoutGrants).getOrElse {
+        val resultForPartyWithoutGrants = grantRepo.findAll(partyWithoutGrants, Pagination()).getOrElse {
             fail("Failed to read grants for party without grants")
         }
-        resultForPartyWithoutGrants.size shouldBe 0
+        resultForPartyWithoutGrants.items.size shouldBe 0
     }
 
     test("findBySource returns grant given sourceType and sourceId)") {

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -12,10 +12,10 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.config.withTransaction
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.PostgresTestContainer
 import no.elhub.auth.features.common.PostgresTestContainerExtension
 import no.elhub.auth.features.common.RepositoryReadError
-import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
 import no.elhub.auth.features.common.party.ExposedPartyRepository

--- a/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
@@ -155,6 +155,105 @@ class ExposedRequestRepositoryTest : FunSpec({
         result.items shouldBe emptyList()
     }
 
+    context("pagination") {
+        test("returns correct page size and totalItems") {
+            val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
+            repeat(5) {
+                requestRepo.insert(AuthorizationRequest.create(
+                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = party,
+                    requestedFrom = party,
+                    requestedTo = party,
+                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                ), scopes)
+            }
+
+            val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 0, size = 2))
+                .getOrElse { fail("findAllAndSortByCreatedAt failed") }
+
+            page.items.size shouldBe 2
+            page.totalItems shouldBe 5
+            page.totalPages shouldBe 3
+        }
+
+        test("returns next page when page=1") {
+            val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
+            repeat(5) {
+                requestRepo.insert(AuthorizationRequest.create(
+                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = party,
+                    requestedFrom = party,
+                    requestedTo = party,
+                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                ), scopes)
+            }
+
+            val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 1, size = 2))
+                .getOrElse { fail("findAllAndSortByCreatedAt failed") }
+
+            page.items.size shouldBe 2
+            page.totalItems shouldBe 5
+        }
+
+        test("returns partial last page") {
+            val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
+            repeat(5) {
+                requestRepo.insert(AuthorizationRequest.create(
+                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = party,
+                    requestedFrom = party,
+                    requestedTo = party,
+                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                ), scopes)
+            }
+
+            val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 2, size = 2))
+                .getOrElse { fail("findAllAndSortByCreatedAt failed") }
+
+            page.items.size shouldBe 1
+            page.totalItems shouldBe 5
+        }
+
+        test("returns empty items but correct totalItems when page is beyond data") {
+            val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
+            repeat(5) {
+                requestRepo.insert(AuthorizationRequest.create(
+                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = party,
+                    requestedFrom = party,
+                    requestedTo = party,
+                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                ), scopes)
+            }
+
+            val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 10, size = 2))
+                .getOrElse { fail("findAllAndSortByCreatedAt failed") }
+
+            page.items shouldBe emptyList()
+            page.totalItems shouldBe 5
+        }
+
+        test("pages do not overlap") {
+            val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
+            repeat(5) {
+                requestRepo.insert(AuthorizationRequest.create(
+                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                    requestedBy = party,
+                    requestedFrom = party,
+                    requestedTo = party,
+                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                ), scopes)
+            }
+
+            val page0 = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 0, size = 2))
+                .getOrElse { fail("page 0 failed") }
+            val page1 = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 1, size = 2))
+                .getOrElse { fail("page 1 failed") }
+
+            (page0.items.map { it.id }.toSet() intersect page1.items.map { it.id }.toSet()) shouldBe emptySet()
+        }
+    }
+
     test("find returns correct request") {
         val requests = List(10) {
             generateRequestWithoutProperties()

--- a/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
@@ -13,6 +13,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import no.elhub.auth.config.TransactionContext
 import no.elhub.auth.config.withTransaction
 import no.elhub.auth.features.common.CreateScopeData
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.PostgresTestContainer
 import no.elhub.auth.features.common.PostgresTestContainerExtension
 import no.elhub.auth.features.common.RunPostgresScriptExtension
@@ -111,17 +112,17 @@ class ExposedRequestRepositoryTest : FunSpec({
             requestRepo.insert(request, scopes)
         }
 
-        val requestsOfTargetParty1 = requestRepo.findAllAndSortByCreatedAt(targetParty1)
+        val requestsOfTargetParty1 = requestRepo.findAllAndSortByCreatedAt(targetParty1, Pagination(size = 200))
             .getOrElse { _ ->
                 fail("findAllAndSortByCreatedAt failed for target party 1")
             }
-        requestsOfTargetParty1.size shouldBe numTargetRequests
+        requestsOfTargetParty1.items.size shouldBe numTargetRequests
 
-        requestRepo.findAllAndSortByCreatedAt(targetParty2)
+        requestRepo.findAllAndSortByCreatedAt(targetParty2, Pagination(size = 200))
             .getOrElse { _ ->
                 fail("findAllAndSortByCreatedAt failed for target party 2")
             }
-        requestsOfTargetParty1.size shouldBe numTargetRequests
+        requestsOfTargetParty1.items.size shouldBe numTargetRequests
     }
 
     test("findAllAndSortByCreatedAt returns requests by createdAt DESC") {
@@ -139,19 +140,19 @@ class ExposedRequestRepositoryTest : FunSpec({
             requestRepo.insert(request, scopes)
         }
 
-        val result = requestRepo.findAllAndSortByCreatedAt(party)
+        val result = requestRepo.findAllAndSortByCreatedAt(party, Pagination(size = 100))
             .getOrElse { throw AssertionError("Repository read failed: $it") }
 
-        val createdAtList = result.map { it.createdAt }
+        val createdAtList = result.items.map { it.createdAt }
 
         createdAtList shouldBe createdAtList.sortedDescending()
     }
 
     test("findAllAndSortByCreatedAt returns empty list for party with no requests") {
         val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
-        val result = requestRepo.findAllAndSortByCreatedAt(party)
+        val result = requestRepo.findAllAndSortByCreatedAt(party, Pagination())
             .getOrElse { throw AssertionError("Repository read failed: $it") }
-        result shouldBe emptyList()
+        result.items shouldBe emptyList()
     }
 
     test("find returns correct request") {

--- a/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
@@ -159,13 +159,16 @@ class ExposedRequestRepositoryTest : FunSpec({
         test("returns correct page size and totalItems") {
             val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
             repeat(5) {
-                requestRepo.insert(AuthorizationRequest.create(
-                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                    requestedBy = party,
-                    requestedFrom = party,
-                    requestedTo = party,
-                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
-                ), scopes)
+                requestRepo.insert(
+                    AuthorizationRequest.create(
+                        type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                        requestedBy = party,
+                        requestedFrom = party,
+                        requestedTo = party,
+                        validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                    ),
+                    scopes
+                )
             }
 
             val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 0, size = 2))
@@ -179,13 +182,16 @@ class ExposedRequestRepositoryTest : FunSpec({
         test("returns next page when page=1") {
             val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
             repeat(5) {
-                requestRepo.insert(AuthorizationRequest.create(
-                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                    requestedBy = party,
-                    requestedFrom = party,
-                    requestedTo = party,
-                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
-                ), scopes)
+                requestRepo.insert(
+                    AuthorizationRequest.create(
+                        type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                        requestedBy = party,
+                        requestedFrom = party,
+                        requestedTo = party,
+                        validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                    ),
+                    scopes
+                )
             }
 
             val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 1, size = 2))
@@ -198,13 +204,16 @@ class ExposedRequestRepositoryTest : FunSpec({
         test("returns partial last page") {
             val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
             repeat(5) {
-                requestRepo.insert(AuthorizationRequest.create(
-                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                    requestedBy = party,
-                    requestedFrom = party,
-                    requestedTo = party,
-                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
-                ), scopes)
+                requestRepo.insert(
+                    AuthorizationRequest.create(
+                        type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                        requestedBy = party,
+                        requestedFrom = party,
+                        requestedTo = party,
+                        validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                    ),
+                    scopes
+                )
             }
 
             val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 2, size = 2))
@@ -217,13 +226,16 @@ class ExposedRequestRepositoryTest : FunSpec({
         test("returns empty items but correct totalItems when page is beyond data") {
             val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
             repeat(5) {
-                requestRepo.insert(AuthorizationRequest.create(
-                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                    requestedBy = party,
-                    requestedFrom = party,
-                    requestedTo = party,
-                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
-                ), scopes)
+                requestRepo.insert(
+                    AuthorizationRequest.create(
+                        type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                        requestedBy = party,
+                        requestedFrom = party,
+                        requestedTo = party,
+                        validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                    ),
+                    scopes
+                )
             }
 
             val page = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 10, size = 2))
@@ -236,13 +248,16 @@ class ExposedRequestRepositoryTest : FunSpec({
         test("pages do not overlap") {
             val party = AuthorizationParty(type = PartyType.Person, id = UUID.randomUUID().toString())
             repeat(5) {
-                requestRepo.insert(AuthorizationRequest.create(
-                    type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                    requestedBy = party,
-                    requestedFrom = party,
-                    requestedTo = party,
-                    validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
-                ), scopes)
+                requestRepo.insert(
+                    AuthorizationRequest.create(
+                        type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                        requestedBy = party,
+                        requestedFrom = party,
+                        requestedTo = party,
+                        validTo = OffsetDateTime.now(ZoneOffset.UTC).plusDays(30),
+                    ),
+                    scopes
+                )
             }
 
             val page0 = requestRepo.findAllAndSortByCreatedAt(party, Pagination(page = 0, size = 2))

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/HandlerTest.kt
@@ -1,0 +1,106 @@
+package no.elhub.auth.features.requests.query
+
+import arrow.core.right
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
+import no.elhub.auth.features.common.RepositoryReadError
+import no.elhub.auth.features.common.currentTimeUtc
+import no.elhub.auth.features.common.party.AuthorizationParty
+import no.elhub.auth.features.common.party.PartyType
+import no.elhub.auth.features.grants.AuthorizationGrant
+import no.elhub.auth.features.grants.common.GrantRepository
+import no.elhub.auth.features.requests.AuthorizationRequest
+import no.elhub.auth.features.requests.common.RequestRepository
+import java.util.UUID
+
+class HandlerTest : FunSpec({
+
+    val authorizedParty = AuthorizationParty(id = "org-entity-1", type = PartyType.OrganizationEntity)
+    val requestedFromParty = AuthorizationParty(id = "person-1", type = PartyType.Person)
+    val requestedToParty = AuthorizationParty(id = "person-2", type = PartyType.Person)
+
+    fun makeRequest(
+        id: UUID = UUID.randomUUID(),
+        approvedBy: AuthorizationParty? = null,
+        grantId: UUID? = null,
+    ) = AuthorizationRequest(
+        id = id,
+        type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+        status = AuthorizationRequest.Status.Pending,
+        validTo = currentTimeUtc().plusDays(1),
+        createdAt = currentTimeUtc(),
+        updatedAt = currentTimeUtc(),
+        requestedBy = authorizedParty,
+        requestedTo = requestedToParty,
+        requestedFrom = requestedFromParty,
+        approvedBy = approvedBy,
+        grantId = grantId,
+        properties = emptyList()
+    )
+
+    fun requestRepoReturning(page: Page<AuthorizationRequest>): RequestRepository =
+        mockk<RequestRepository> {
+            coEvery { findAllAndSortByCreatedAt(any(), any()) } returns page.right()
+        }
+
+    fun grantRepoReturning(result: Map<UUID, AuthorizationGrant>): GrantRepository =
+        mockk<GrantRepository> {
+            coEvery { findBySourceIds(any(), any()) } returns result.right()
+        }
+
+    test("passes pagination to repository and preserves page metadata") {
+        val pagination = Pagination(page = 1, size = 5)
+        val request = makeRequest()
+        val requestRepo = requestRepoReturning(Page(listOf(request), 10L, pagination))
+        val handler = Handler(requestRepo, grantRepoReturning(emptyMap()))
+
+        val response = handler(Query(authorizedParty = authorizedParty, pagination = pagination))
+
+        coVerify(exactly = 1) { requestRepo.findAllAndSortByCreatedAt(authorizedParty, pagination) }
+        val page = response.shouldBeRight()
+        page.pagination shouldBe pagination
+        page.totalItems shouldBe 10L
+        page.totalPages shouldBe 2
+    }
+
+    test("resolves grant id for approved request") {
+        val pagination = Pagination()
+        val requestId = UUID.randomUUID()
+        val approvedRequest = makeRequest(id = requestId, approvedBy = requestedToParty)
+        val grant = AuthorizationGrant.create(
+            grantedFor = requestedFromParty,
+            grantedBy = requestedToParty,
+            grantedTo = authorizedParty,
+            sourceType = AuthorizationGrant.SourceType.Request,
+            sourceId = requestId,
+            scopeIds = listOf(UUID.randomUUID()),
+            validFrom = currentTimeUtc(),
+            validTo = currentTimeUtc().plusDays(365),
+        )
+        val requestRepo = requestRepoReturning(Page(listOf(approvedRequest), 1L, pagination))
+        val handler = Handler(requestRepo, grantRepoReturning(mapOf(requestId to grant)))
+
+        val response = handler(Query(authorizedParty = authorizedParty, pagination = pagination))
+
+        val page = response.shouldBeRight()
+        page.items[0].grantId shouldBe grant.id
+    }
+
+    test("leaves grant id null for unapproved request") {
+        val pagination = Pagination()
+        val unapprovedRequest = makeRequest(approvedBy = null)
+        val requestRepo = requestRepoReturning(Page(listOf(unapprovedRequest), 1L, pagination))
+        val handler = Handler(requestRepo, grantRepoReturning(emptyMap()))
+
+        val response = handler(Query(authorizedParty = authorizedParty, pagination = pagination))
+
+        val page = response.shouldBeRight()
+        page.items[0].grantId shouldBe null
+    }
+})

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/HandlerTest.kt
@@ -9,7 +9,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.Pagination
-import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.currentTimeUtc
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyType

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
@@ -15,6 +15,8 @@ import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import no.elhub.auth.features.common.Page
+import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.QueryError
 import no.elhub.auth.features.common.auth.AuthError
 import no.elhub.auth.features.common.auth.AuthorizationProvider
@@ -88,7 +90,7 @@ class RouteTest : FunSpec({
 
     test("GET should return OK with empty list when handler returns no requests") {
         coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
-        coEvery { handler.invoke(any()) } returns emptyList<AuthorizationRequest>().right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 0L, Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/")
@@ -114,7 +116,7 @@ class RouteTest : FunSpec({
             properties = emptyList()
         )
 
-        coEvery { handler.invoke(any()) } returns listOf(authorizationRequest).right()
+        coEvery { handler.invoke(any()) } returns Page(listOf(authorizationRequest), 1L, Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/")
@@ -169,7 +171,7 @@ class RouteTest : FunSpec({
             properties = emptyList()
         )
 
-        coEvery { handler.invoke(any()) } returns listOf(request1, request2).right()
+        coEvery { handler.invoke(any()) } returns Page(listOf(request1, request2), 2L, Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/")

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
@@ -201,20 +201,26 @@ class RouteTest : FunSpec({
         coVerify(exactly = 1) { handler.invoke(match { it.pagination == Pagination(page = 1, size = 5) }) }
     }
 
-    test("GET response meta contains pagination fields") {
-        val pagination = Pagination(page = 0, size = 10)
+    test("GET response meta and links contain correct pagination fields") {
+        val pagination = Pagination(page = 1, size = 5)
         coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
-        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 3L, pagination).right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 15L, pagination).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/")
             response.status shouldBe HttpStatusCode.OK
             val body = response.body<JsonObject>()
             val meta = body["meta"]!!.jsonObject
-            meta["totalItems"]!!.jsonPrimitive.content shouldBe "3"
-            meta["totalPages"]!!.jsonPrimitive.content shouldBe "1"
-            meta["page"]!!.jsonPrimitive.content shouldBe "0"
-            meta["pageSize"]!!.jsonPrimitive.content shouldBe "10"
+            meta["totalItems"]!!.jsonPrimitive.content shouldBe "15"
+            meta["totalPages"]!!.jsonPrimitive.content shouldBe "3"
+            meta["page"]!!.jsonPrimitive.content shouldBe "1"
+            meta["pageSize"]!!.jsonPrimitive.content shouldBe "5"
+            val links = body["links"]!!.jsonObject
+            links["self"]!!.jsonPrimitive.content shouldBe "$REQUESTS_PATH?page[number]=1&page[size]=5"
+            links["first"]!!.jsonPrimitive.content shouldBe "$REQUESTS_PATH?page[number]=0&page[size]=5"
+            links["last"]!!.jsonPrimitive.content shouldBe "$REQUESTS_PATH?page[number]=2&page[size]=5"
+            links["prev"]!!.jsonPrimitive.content shouldBe "$REQUESTS_PATH?page[number]=0&page[size]=5"
+            links["next"]!!.jsonPrimitive.content shouldBe "$REQUESTS_PATH?page[number]=2&page[size]=5"
         }
     }
 })

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
@@ -147,7 +147,8 @@ class RouteTest : FunSpec({
         coVerify(exactly = 1) { handler.invoke(any()) }
     }
 
-    test("GET should return OK with multiple items when handler returns multiple requests") {        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+    test("GET should return OK with multiple items when handler returns multiple requests") {
+        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
         val request1 = AuthorizationRequest(
             id = UUID.randomUUID(),
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
@@ -15,6 +15,9 @@ import io.ktor.server.testing.testApplication
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import no.elhub.auth.features.common.Page
 import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.QueryError
@@ -144,8 +147,7 @@ class RouteTest : FunSpec({
         coVerify(exactly = 1) { handler.invoke(any()) }
     }
 
-    test("GET should return OK with multiple items when handler returns multiple requests") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+    test("GET should return OK with multiple items when handler returns multiple requests") {        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
         val request1 = AuthorizationRequest(
             id = UUID.randomUUID(),
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
@@ -186,5 +188,32 @@ class RouteTest : FunSpec({
             body.data[1].attributes.requestType shouldBe "MoveInAndChangeOfBalanceSupplierForPerson"
         }
         coVerify(exactly = 1) { handler.invoke(any()) }
+    }
+
+    test("GET with page params passes correct Pagination to handler") {
+        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 0L, Pagination(page = 1, size = 5)).right()
+        testApplication {
+            setupAppWith { route(handler, authProvider) }
+            client.get("/?page[number]=1&page[size]=5")
+        }
+        coVerify(exactly = 1) { handler.invoke(match { it.pagination == Pagination(page = 1, size = 5) }) }
+    }
+
+    test("GET response meta contains pagination fields") {
+        val pagination = Pagination(page = 0, size = 10)
+        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 3L, pagination).right()
+        testApplication {
+            setupAppWith { route(handler, authProvider) }
+            val response = client.get("/")
+            response.status shouldBe HttpStatusCode.OK
+            val body = response.body<JsonObject>()
+            val meta = body["meta"]!!.jsonObject
+            meta["totalItems"]!!.jsonPrimitive.content shouldBe "3"
+            meta["totalPages"]!!.jsonPrimitive.content shouldBe "1"
+            meta["page"]!!.jsonPrimitive.content shouldBe "0"
+            meta["pageSize"]!!.jsonPrimitive.content shouldBe "10"
+        }
     }
 })


### PR DESCRIPTION
More work from https://elhub.atlassian.net/browse/TDX-1471

Implements pagination using db queries with `LIMIT` and `OFFSET`, which are wrapped in a `Page<T>`. Additional pagination fields are added to `meta`. I chose not to include links to previous, next, first, and last pages as I think this can easily be constructed by the client.

Affects the endpoints:
- GET `/authorization-documents/`
- GET `/authorization-grants/`
- GET `/authorization-requests/`