### PR TITLE
fix(errorhandling): Replace regex in error formatting and fix incorrect 'data' reference [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
+++ b/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
@@ -54,18 +54,29 @@ fun Application.configureErrorHandling() {
 }
 
 private fun formatDeserializationDetail(raw: String): String {
-    val singleLine = raw.replace(Regex("\\s+"), " ").trim()
-    val path = Regex("""at path (\S+)""").find(singleLine)?.groupValues?.get(1)
+    // kotlinx.serialization appends the path to the first line of the message in one of two formats:
+    //   - enum errors (StreamingJsonDecoder):  "... at path $.field"   (no colon)
+    //   - lexer/structural errors:             "... at path: $.field"  (with colon)
+    // Both use the stable $.field.subField notation.
+    val firstLine = raw.lineSequence().first()
+    val path = firstLine
+        .substringAfterLast("at path: ", missingDelimiterValue = "")
+        .ifEmpty { firstLine.substringAfterLast("at path ", missingDelimiterValue = "") }
+        .ifEmpty { null }
 
-    val enumField = Regex("""at path \S*?\.([A-Za-z0-9_]+)\b""").find(singleLine)?.groupValues?.get(1)
-    val enumValue = Regex("""name '([^']+)'""").find(singleLine)?.groupValues?.get(1)
+    // Enum errors follow the pattern: "<SerialName> does not contain element with name '<value>'"
+    val invalidEnumValue = firstLine
+        .substringAfter("does not contain element with name '", missingDelimiterValue = "")
+        .substringBefore("'")
+        .ifEmpty { null }
 
     return when {
-        enumField != null && path != null && enumValue != null ->
-            "Invalid value '$enumValue' for field '$enumField' at $path"
+        path != null && invalidEnumValue != null ->
+            "Invalid value '$invalidEnumValue' for field '${path.substringAfterLast(".")}' at $path"
 
-        else ->
-            singleLine
-                .replace(Regex("""\bno\.elhub\.[\w.]+\.(\w+\.\w+)\b"""), "$1")
+        path != null ->
+            "Invalid value for field '${path.substringAfterLast(".")}' at $path"
+
+        else -> "Invalid request body"
     }
 }

--- a/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
@@ -276,7 +276,7 @@ class AuthorizationDocumentRouteTest :
                         this[0].apply {
                             status shouldBe "400"
                             title shouldBe "Invalid field value in request body"
-                            detail shouldBe "Invalid value 'TEST' for field 'data' at $.data.meta.requestedBy.idType"
+                            detail shouldBe "Invalid value 'TEST' for field 'idType' at $.data.meta.requestedBy.idType"
                         }
                     }
                     responseJson.meta.apply {

--- a/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
@@ -190,7 +190,7 @@ class RouteTest : FunSpec({
                 this[0].apply {
                     status shouldBe "400"
                     title shouldBe "Invalid field value in request body"
-                    detail shouldBe "Invalid value 'TEST' for field 'data' at $.data.meta.requestedBy.idType"
+                    detail shouldBe "Invalid value 'TEST' for field 'idType' at $.data.meta.requestedBy.idType"
                 }
             }
             coVerify(exactly = 0) { handler.invoke(any()) }

--- a/src/test/kotlin/no/elhub/auth/features/requests/route/AuthorizationRequestRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/route/AuthorizationRequestRouteTest.kt
@@ -733,7 +733,7 @@ class AuthorizationRequestRouteTest : FunSpec({
                     this[0].apply {
                         status shouldBe "400"
                         title shouldBe "Invalid field value in request body"
-                        detail shouldBe "Invalid value 'TEST' for field 'data' at $.data.meta.requestedBy.idType"
+                        detail shouldBe "Invalid value 'TEST' for field 'idType' at $.data.meta.requestedBy.idType"
                     }
                 }
                 responseJson.meta.apply {


### PR DESCRIPTION
Part of https://elhub.atlassian.net/browse/TDX-1470

- Fixes reference to `data` field (or other parent objects) in the 400 response message when the invalid field value is in fact nested inside.
- Removes regex, hopefully making the formatting function comprehensible.