### PR TITLE
fix(errorhandling): Handle SerializationException and MissingFieldException at route level instead of as global fallback [patch]

### DIFF
--- a/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
+++ b/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
@@ -1,13 +1,10 @@
 package no.elhub.auth.config
 
-import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.MissingFieldException
-import no.elhub.auth.features.common.buildApiErrorResponse
 import no.elhub.auth.features.common.toInternalServerApiErrorResponse
 import org.slf4j.LoggerFactory
 
@@ -18,26 +15,9 @@ fun Application.configureErrorHandling() {
     install(StatusPages) {
         exception<Throwable> { call, cause ->
             val root = generateSequence(cause) { it.cause }.last()
-            when (root) {
-                is MissingFieldException -> {
-                    logger.error("Missing required field in request body", root)
-                    val detail = "Field '${root.missingFields}' is missing or invalid"
-                    val (status, body) = buildApiErrorResponse(
-                        HttpStatusCode.BadRequest,
-                        "Missing required field in request body",
-                        detail
-                    )
-                    call.respond(status, body)
-                }
-
-                else -> {
-                    // domain/expected errors are handled via Arrow with Either, so reaching this block
-                    // means an unexpected failure, and we return a generic 500 internal server error
-                    logger.error("Unhandled exception", cause)
-                    val (status, body) = toInternalServerApiErrorResponse()
-                    call.respond(status, body)
-                }
-            }
+            logger.error("Unhandled exception", cause)
+            val (status, body) = toInternalServerApiErrorResponse()
+            call.respond(status, body)
         }
     }
 }

--- a/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
+++ b/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
@@ -31,16 +31,6 @@ fun Application.configureErrorHandling() {
                     call.respond(status, body)
                 }
 
-                is SerializationException -> {
-                    logger.error("Failed to deserialize request body: {}", root.localizedMessage)
-                    val (status, body) = buildApiErrorResponse(
-                        HttpStatusCode.BadRequest,
-                        "Invalid field value in request body",
-                        formatDeserializationDetail(root.message ?: "Invalid request body")
-                    )
-                    call.respond(status, body)
-                }
-
                 else -> {
                     // domain/expected errors are handled via Arrow with Either, so reaching this block
                     // means an unexpected failure, and we return a generic 500 internal server error
@@ -53,19 +43,3 @@ fun Application.configureErrorHandling() {
     }
 }
 
-private fun formatDeserializationDetail(raw: String): String {
-    val singleLine = raw.replace(Regex("\\s+"), " ").trim()
-    val path = Regex("""at path (\S+)""").find(singleLine)?.groupValues?.get(1)
-
-    val enumField = Regex("""at path \S*?\.([A-Za-z0-9_]+)\b""").find(singleLine)?.groupValues?.get(1)
-    val enumValue = Regex("""name '([^']+)'""").find(singleLine)?.groupValues?.get(1)
-
-    return when {
-        enumField != null && path != null && enumValue != null ->
-            "Invalid value '$enumValue' for field '$enumField' at $path"
-
-        else ->
-            singleLine
-                .replace(Regex("""\bno\.elhub\.[\w.]+\.(\w+\.\w+)\b"""), "$1")
-    }
-}

--- a/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
+++ b/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
@@ -7,7 +7,6 @@ import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
-import kotlinx.serialization.SerializationException
 import no.elhub.auth.features.common.buildApiErrorResponse
 import no.elhub.auth.features.common.toInternalServerApiErrorResponse
 import org.slf4j.LoggerFactory
@@ -42,4 +41,3 @@ fun Application.configureErrorHandling() {
         }
     }
 }
-

--- a/src/main/kotlin/no/elhub/auth/features/common/ApplicationCallExtensions.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/ApplicationCallExtensions.kt
@@ -1,0 +1,56 @@
+package no.elhub.auth.features.common
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receive
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.SerializationException
+
+@OptIn(ExperimentalSerializationApi::class)
+internal suspend inline fun <reified T : Any> ApplicationCall.receiveEither(): Either<InputError, T> =
+    try {
+        receive<T>().right()
+    } catch (e: Exception) {
+        val root = generateSequence(e as Throwable) { it.cause }.last()
+        when (root) {
+            is MissingFieldException ->
+                InputError.MissingFieldError(root.missingFields).left()
+
+            is SerializationException ->
+                InputError.InvalidFieldValueError(formatDeserializationDetail(root.message ?: "Invalid request body"))
+                    .left()
+
+            else -> throw e
+        }
+    }
+
+private fun formatDeserializationDetail(raw: String): String {
+    // kotlinx.serialization appends the path to the first line of the message in one of two formats:
+    //   - enum errors (StreamingJsonDecoder):  "... at path $.field"   (no colon)
+    //   - lexer/structural errors:             "... at path: $.field"  (with colon)
+    // Both use the stable $.field.subField notation.
+    val firstLine = raw.lineSequence().first()
+    val path = firstLine
+        .substringAfterLast("at path: ", missingDelimiterValue = "")
+        .ifEmpty { firstLine.substringAfterLast("at path ", missingDelimiterValue = "") }
+        .ifEmpty { null }
+
+    // Enum errors follow the pattern: "<SerialName> does not contain element with name '<value>'"
+    val invalidEnumValue = firstLine
+        .substringAfter("does not contain element with name '", missingDelimiterValue = "")
+        .substringBefore("'")
+        .ifEmpty { null }
+
+    return when {
+        path != null && invalidEnumValue != null ->
+            "Invalid value '$invalidEnumValue' for field '${path.substringAfterLast(".")}' at $path"
+
+        path != null ->
+            "Invalid value for field '${path.substringAfterLast(".")}' at $path"
+
+        else -> "Invalid request body"
+    }
+}

--- a/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
@@ -12,6 +12,8 @@ sealed class InputError : Error {
     data object MissingInputError : InputError()
     data object MalformedInputError : InputError()
     data object IdMismatchError : InputError()
+    data class MissingFieldError(val fields: List<String>) : InputError()
+    data class InvalidFieldValueError(val detail: String) : InputError()
 }
 
 sealed class CommandError : Error {
@@ -113,16 +115,28 @@ fun InputError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection
             detail = "Necessary information was not provided",
         )
 
-        InputError.MalformedInputError -> buildApiErrorResponse(
+        is InputError.MalformedInputError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
             title = "Invalid input",
             detail = "The provided payload did not satisfy the expected format"
         )
 
-        InputError.IdMismatchError -> buildApiErrorResponse(
+        is InputError.IdMismatchError -> buildApiErrorResponse(
             status = HttpStatusCode.Conflict,
             title = "Resource id mismatch",
             detail = "Expected 'data.id' to be the same as in URL path {id}"
+        )
+
+        is InputError.MissingFieldError -> buildApiErrorResponse(
+            status = HttpStatusCode.BadRequest,
+            title = "Missing required field in request body",
+            detail = "Field '${this.fields}' is missing or invalid"
+        )
+
+        is InputError.InvalidFieldValueError -> buildApiErrorResponse(
+            status = HttpStatusCode.BadRequest,
+            title = "Invalid field value in request body",
+            detail = this.detail
         )
     }
 

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/Route.kt
@@ -2,12 +2,13 @@ package no.elhub.auth.features.documents.create
 
 import arrow.core.getOrElse
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
+import no.elhub.auth.features.common.receiveEither
+import no.elhub.auth.features.common.toApiErrorResponse
 import no.elhub.auth.features.common.toTypeMismatchApiErrorResponse
 import no.elhub.auth.features.documents.create.dto.JsonApiCreateDocumentRequest
 import no.elhub.auth.features.documents.create.dto.toCreateDocumentResponse
@@ -28,7 +29,12 @@ fun Route.route(
                 return@post
             }
 
-        val requestBody = call.receive<JsonApiCreateDocumentRequest>()
+        val requestBody = call.receiveEither<JsonApiCreateDocumentRequest>()
+            .getOrElse { error ->
+                val (status, body) = error.toApiErrorResponse()
+                call.respond(status, body)
+                return@post
+            }
 
         if (requestBody.data.type != "AuthorizationDocument") {
             val (status, message) = toTypeMismatchApiErrorResponse(

--- a/src/main/kotlin/no/elhub/auth/features/grants/consume/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/consume/Route.kt
@@ -2,12 +2,12 @@ package no.elhub.auth.features.grants.consume
 
 import arrow.core.getOrElse
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.patch
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
+import no.elhub.auth.features.common.receiveEither
 import no.elhub.auth.features.common.toApiErrorResponse
 import no.elhub.auth.features.common.toTypeMismatchApiErrorResponse
 import no.elhub.auth.features.common.validateDataId
@@ -36,7 +36,12 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
                 return@patch
             }
 
-        val requestBody = call.receive<JsonApiConsumeRequest>()
+        val requestBody = call.receiveEither<JsonApiConsumeRequest>()
+            .getOrElse { error ->
+                val (status, body) = error.toApiErrorResponse()
+                call.respond(status, body)
+                return@patch
+            }
 
         validateDataId(requestBody.data.id, grantId)
             .getOrElse { err ->

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/Route.kt
@@ -2,12 +2,13 @@ package no.elhub.auth.features.requests.create
 
 import arrow.core.getOrElse
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.post
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
+import no.elhub.auth.features.common.receiveEither
+import no.elhub.auth.features.common.toApiErrorResponse
 import no.elhub.auth.features.common.toTypeMismatchApiErrorResponse
 import no.elhub.auth.features.requests.create.dto.JsonApiCreateRequest
 import no.elhub.auth.features.requests.create.dto.toCreateResponse
@@ -29,7 +30,12 @@ fun Route.route(
                 return@post
             }
 
-        val requestBody = call.receive<JsonApiCreateRequest>()
+        val requestBody = call.receiveEither<JsonApiCreateRequest>()
+            .getOrElse { error ->
+                val (status, body) = error.toApiErrorResponse()
+                call.respond(status, body)
+                return@post
+            }
 
         if (requestBody.data.type != "AuthorizationRequest") {
             val (status, message) = toTypeMismatchApiErrorResponse(

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Route.kt
@@ -2,12 +2,12 @@ package no.elhub.auth.features.requests.update
 
 import arrow.core.getOrElse
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.patch
 import no.elhub.auth.features.common.auth.AuthorizationProvider
 import no.elhub.auth.features.common.auth.toApiErrorResponse
+import no.elhub.auth.features.common.receiveEither
 import no.elhub.auth.features.common.toApiErrorResponse
 import no.elhub.auth.features.common.toTypeMismatchApiErrorResponse
 import no.elhub.auth.features.common.validateDataId
@@ -38,7 +38,12 @@ fun Route.route(
                 return@patch
             }
 
-        val requestBody = call.receive<JsonApiUpdateRequest>()
+        val requestBody = call.receiveEither<JsonApiUpdateRequest>()
+            .getOrElse { error ->
+                val (status, body) = error.toApiErrorResponse()
+                call.respond(status, body)
+                return@patch
+            }
 
         validateDataId(requestBody.data.id, requestId)
             .getOrElse { err ->

--- a/src/test/kotlin/no/elhub/auth/features/common/ApplicationCallExtensionsTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/common/ApplicationCallExtensionsTest.kt
@@ -1,0 +1,104 @@
+package no.elhub.auth.features.common
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.response.respond
+import io.ktor.server.routing.post
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.Serializable
+import no.elhub.auth.setupAppWith
+import no.elhub.devxp.jsonapi.response.JsonApiErrorCollection
+
+@Serializable
+private data class TestDto(val name: String, val value: Int)
+
+class ApplicationCallExtensionsTest : FunSpec({
+
+    fun setupTestRoute(builder: io.ktor.server.routing.Routing.() -> Unit) = builder
+
+    test("receiveEither returns Right with parsed body when JSON is valid") {
+        testApplication {
+            setupAppWith {
+                post("/test") {
+                    call.receiveEither<TestDto>().fold(
+                        ifLeft = { error ->
+                            val (status, body) = error.toApiErrorResponse()
+                            call.respond(status, body)
+                        },
+                        ifRight = { dto -> call.respond(HttpStatusCode.OK, dto) }
+                    )
+                }
+            }
+            val response = client.post("/test") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"hello","value":42}""")
+            }
+            response.status shouldBe HttpStatusCode.OK
+        }
+    }
+
+    test("receiveEither returns Left(InvalidFieldValueError) when field has wrong type") {
+        testApplication {
+            setupAppWith {
+                post("/test") {
+                    call.receiveEither<TestDto>().fold(
+                        ifLeft = { error ->
+                            val (status, body) = error.toApiErrorResponse()
+                            call.respond(status, body)
+                        },
+                        ifRight = { dto -> call.respond(HttpStatusCode.OK, dto) }
+                    )
+                }
+            }
+            val response = client.post("/test") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"hello","value":"not-an-int"}""")
+            }
+            response.status shouldBe HttpStatusCode.BadRequest
+            val body: JsonApiErrorCollection = response.body()
+            body.errors.apply {
+                size shouldBe 1
+                this[0].apply {
+                    status shouldBe "400"
+                    title shouldBe "Invalid field value in request body"
+                }
+            }
+        }
+    }
+
+    test("receiveEither returns Left(MissingFieldError) when required field is absent") {
+        testApplication {
+            setupAppWith {
+                post("/test") {
+                    call.receiveEither<TestDto>().fold(
+                        ifLeft = { error ->
+                            val (status, body) = error.toApiErrorResponse()
+                            call.respond(status, body)
+                        },
+                        ifRight = { dto -> call.respond(HttpStatusCode.OK, dto) }
+                    )
+                }
+            }
+            val response = client.post("/test") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"name":"hello"}""")
+            }
+            response.status shouldBe HttpStatusCode.BadRequest
+            val body: JsonApiErrorCollection = response.body()
+            body.errors.apply {
+                size shouldBe 1
+                this[0].apply {
+                    status shouldBe "400"
+                    title shouldBe "Missing required field in request body"
+                    detail shouldBe "Field '[value]' is missing or invalid"
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/AuthorizationDocumentRouteTest.kt
@@ -276,7 +276,7 @@ class AuthorizationDocumentRouteTest :
                         this[0].apply {
                             status shouldBe "400"
                             title shouldBe "Invalid field value in request body"
-                            detail shouldBe "Invalid value 'TEST' for field 'data' at $.data.meta.requestedBy.idType"
+                            detail shouldBe "Invalid value 'TEST' for field 'idType' at $.data.meta.requestedBy.idType"
                         }
                     }
                     responseJson.meta.apply {

--- a/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
@@ -190,7 +190,7 @@ class RouteTest : FunSpec({
                 this[0].apply {
                     status shouldBe "400"
                     title shouldBe "Invalid field value in request body"
-                    detail shouldBe "Invalid value 'TEST' for field 'data' at $.data.meta.requestedBy.idType"
+                    detail shouldBe "Invalid value 'TEST' for field 'idType' at $.data.meta.requestedBy.idType"
                 }
             }
             coVerify(exactly = 0) { handler.invoke(any()) }

--- a/src/test/kotlin/no/elhub/auth/features/requests/route/AuthorizationRequestRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/route/AuthorizationRequestRouteTest.kt
@@ -750,34 +750,34 @@ class AuthorizationRequestRouteTest : FunSpec({
                         setBody(
                             JsonApiCreateRequest(
                                 data =
-                                    JsonApiRequestResourceObjectWithMeta(
-                                        type = "AuthorizationRequest",
-                                        attributes =
-                                            CreateRequestAttributes(
-                                                requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                                            ),
-                                        meta =
-                                            CreateRequestMeta(
-                                                requestedBy = PartyIdentifier(
-                                                    PartyIdentifierType.GlobalLocationNumber,
-                                                    "0107000000021"
-                                                ),
-                                                requestedFrom = PartyIdentifier(
-                                                    PartyIdentifierType.NationalIdentityNumber,
-                                                    REQUESTED_FROM_NIN
-                                                ),
-                                                requestedFromName = "",
-                                                requestedTo = PartyIdentifier(
-                                                    PartyIdentifierType.NationalIdentityNumber,
-                                                    REQUESTED_TO_NIN
-                                                ),
-                                                requestedForMeteringPointId = "123456789012345678",
-                                                requestedForMeteringPointAddress = "quaerendum",
-                                                balanceSupplierName = "Balance Supplier",
-                                                balanceSupplierContractName = "Selena Chandler",
-                                                redirectURI = "https://example.com",
-                                            ),
+                                JsonApiRequestResourceObjectWithMeta(
+                                    type = "AuthorizationRequest",
+                                    attributes =
+                                    CreateRequestAttributes(
+                                        requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
                                     ),
+                                    meta =
+                                    CreateRequestMeta(
+                                        requestedBy = PartyIdentifier(
+                                            PartyIdentifierType.GlobalLocationNumber,
+                                            "0107000000021"
+                                        ),
+                                        requestedFrom = PartyIdentifier(
+                                            PartyIdentifierType.NationalIdentityNumber,
+                                            REQUESTED_FROM_NIN
+                                        ),
+                                        requestedFromName = "",
+                                        requestedTo = PartyIdentifier(
+                                            PartyIdentifierType.NationalIdentityNumber,
+                                            REQUESTED_TO_NIN
+                                        ),
+                                        requestedForMeteringPointId = "123456789012345678",
+                                        requestedForMeteringPointAddress = "quaerendum",
+                                        balanceSupplierName = "Balance Supplier",
+                                        balanceSupplierContractName = "Selena Chandler",
+                                        redirectURI = "https://example.com",
+                                    ),
+                                ),
                             ),
                         )
                     }
@@ -806,34 +806,34 @@ class AuthorizationRequestRouteTest : FunSpec({
                     setBody(
                         JsonApiCreateRequest(
                             data =
-                                JsonApiRequestResourceObjectWithMeta(
-                                    type = "AuthorizationRequest",
-                                    attributes =
-                                        CreateRequestAttributes(
-                                            requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
-                                        ),
-                                    meta =
-                                        CreateRequestMeta(
-                                            requestedBy = PartyIdentifier(
-                                                PartyIdentifierType.GlobalLocationNumber,
-                                                "0107000000021"
-                                            ),
-                                            requestedFrom = PartyIdentifier(
-                                                PartyIdentifierType.NationalIdentityNumber,
-                                                "123"
-                                            ),
-                                            requestedFromName = "Hillary Orr",
-                                            requestedTo = PartyIdentifier(
-                                                PartyIdentifierType.NationalIdentityNumber,
-                                                REQUESTED_TO_NIN
-                                            ),
-                                            requestedForMeteringPointId = "123456789012345678",
-                                            requestedForMeteringPointAddress = "quaerendum",
-                                            balanceSupplierName = "Balance Supplier",
-                                            balanceSupplierContractName = "Selena Chandler",
-                                            redirectURI = "https://example.com",
-                                        ),
+                            JsonApiRequestResourceObjectWithMeta(
+                                type = "AuthorizationRequest",
+                                attributes =
+                                CreateRequestAttributes(
+                                    requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
                                 ),
+                                meta =
+                                CreateRequestMeta(
+                                    requestedBy = PartyIdentifier(
+                                        PartyIdentifierType.GlobalLocationNumber,
+                                        "0107000000021"
+                                    ),
+                                    requestedFrom = PartyIdentifier(
+                                        PartyIdentifierType.NationalIdentityNumber,
+                                        "123"
+                                    ),
+                                    requestedFromName = "Hillary Orr",
+                                    requestedTo = PartyIdentifier(
+                                        PartyIdentifierType.NationalIdentityNumber,
+                                        REQUESTED_TO_NIN
+                                    ),
+                                    requestedForMeteringPointId = "123456789012345678",
+                                    requestedForMeteringPointAddress = "quaerendum",
+                                    balanceSupplierName = "Balance Supplier",
+                                    balanceSupplierContractName = "Selena Chandler",
+                                    redirectURI = "https://example.com",
+                                ),
+                            ),
                         ),
                     )
                 }

--- a/src/test/kotlin/no/elhub/auth/features/requests/route/AuthorizationRequestRouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/route/AuthorizationRequestRouteTest.kt
@@ -733,7 +733,7 @@ class AuthorizationRequestRouteTest : FunSpec({
                     this[0].apply {
                         status shouldBe "400"
                         title shouldBe "Invalid field value in request body"
-                        detail shouldBe "Invalid value 'TEST' for field 'data' at $.data.meta.requestedBy.idType"
+                        detail shouldBe "Invalid value 'TEST' for field 'idType' at $.data.meta.requestedBy.idType"
                     }
                 }
                 responseJson.meta.apply {
@@ -750,34 +750,34 @@ class AuthorizationRequestRouteTest : FunSpec({
                         setBody(
                             JsonApiCreateRequest(
                                 data =
-                                JsonApiRequestResourceObjectWithMeta(
-                                    type = "AuthorizationRequest",
-                                    attributes =
-                                    CreateRequestAttributes(
-                                        requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                                    JsonApiRequestResourceObjectWithMeta(
+                                        type = "AuthorizationRequest",
+                                        attributes =
+                                            CreateRequestAttributes(
+                                                requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                                            ),
+                                        meta =
+                                            CreateRequestMeta(
+                                                requestedBy = PartyIdentifier(
+                                                    PartyIdentifierType.GlobalLocationNumber,
+                                                    "0107000000021"
+                                                ),
+                                                requestedFrom = PartyIdentifier(
+                                                    PartyIdentifierType.NationalIdentityNumber,
+                                                    REQUESTED_FROM_NIN
+                                                ),
+                                                requestedFromName = "",
+                                                requestedTo = PartyIdentifier(
+                                                    PartyIdentifierType.NationalIdentityNumber,
+                                                    REQUESTED_TO_NIN
+                                                ),
+                                                requestedForMeteringPointId = "123456789012345678",
+                                                requestedForMeteringPointAddress = "quaerendum",
+                                                balanceSupplierName = "Balance Supplier",
+                                                balanceSupplierContractName = "Selena Chandler",
+                                                redirectURI = "https://example.com",
+                                            ),
                                     ),
-                                    meta =
-                                    CreateRequestMeta(
-                                        requestedBy = PartyIdentifier(
-                                            PartyIdentifierType.GlobalLocationNumber,
-                                            "0107000000021"
-                                        ),
-                                        requestedFrom = PartyIdentifier(
-                                            PartyIdentifierType.NationalIdentityNumber,
-                                            REQUESTED_FROM_NIN
-                                        ),
-                                        requestedFromName = "",
-                                        requestedTo = PartyIdentifier(
-                                            PartyIdentifierType.NationalIdentityNumber,
-                                            REQUESTED_TO_NIN
-                                        ),
-                                        requestedForMeteringPointId = "123456789012345678",
-                                        requestedForMeteringPointAddress = "quaerendum",
-                                        balanceSupplierName = "Balance Supplier",
-                                        balanceSupplierContractName = "Selena Chandler",
-                                        redirectURI = "https://example.com",
-                                    ),
-                                ),
                             ),
                         )
                     }
@@ -806,34 +806,34 @@ class AuthorizationRequestRouteTest : FunSpec({
                     setBody(
                         JsonApiCreateRequest(
                             data =
-                            JsonApiRequestResourceObjectWithMeta(
-                                type = "AuthorizationRequest",
-                                attributes =
-                                CreateRequestAttributes(
-                                    requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                                JsonApiRequestResourceObjectWithMeta(
+                                    type = "AuthorizationRequest",
+                                    attributes =
+                                        CreateRequestAttributes(
+                                            requestType = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
+                                        ),
+                                    meta =
+                                        CreateRequestMeta(
+                                            requestedBy = PartyIdentifier(
+                                                PartyIdentifierType.GlobalLocationNumber,
+                                                "0107000000021"
+                                            ),
+                                            requestedFrom = PartyIdentifier(
+                                                PartyIdentifierType.NationalIdentityNumber,
+                                                "123"
+                                            ),
+                                            requestedFromName = "Hillary Orr",
+                                            requestedTo = PartyIdentifier(
+                                                PartyIdentifierType.NationalIdentityNumber,
+                                                REQUESTED_TO_NIN
+                                            ),
+                                            requestedForMeteringPointId = "123456789012345678",
+                                            requestedForMeteringPointAddress = "quaerendum",
+                                            balanceSupplierName = "Balance Supplier",
+                                            balanceSupplierContractName = "Selena Chandler",
+                                            redirectURI = "https://example.com",
+                                        ),
                                 ),
-                                meta =
-                                CreateRequestMeta(
-                                    requestedBy = PartyIdentifier(
-                                        PartyIdentifierType.GlobalLocationNumber,
-                                        "0107000000021"
-                                    ),
-                                    requestedFrom = PartyIdentifier(
-                                        PartyIdentifierType.NationalIdentityNumber,
-                                        "123"
-                                    ),
-                                    requestedFromName = "Hillary Orr",
-                                    requestedTo = PartyIdentifier(
-                                        PartyIdentifierType.NationalIdentityNumber,
-                                        REQUESTED_TO_NIN
-                                    ),
-                                    requestedForMeteringPointId = "123456789012345678",
-                                    requestedForMeteringPointAddress = "quaerendum",
-                                    balanceSupplierName = "Balance Supplier",
-                                    balanceSupplierContractName = "Selena Chandler",
-                                    redirectURI = "https://example.com",
-                                ),
-                            ),
                         ),
                     )
                 }


### PR DESCRIPTION
- Extension function to `RouteCall` enabling explicit handling of bad request scenarios instead of falling back to the global error handler.
- Replace regex in detail formatter function.
- Fix wrong attribute reference in detail formatter function.
- Global error handler now *only* covers unexpected cases that should produce a standard 500 message.