### PR TITLE
fix(networking): Switch to apache5 for PDP HTTP client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-conte
 ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref = "ktor" }
 ktor-client-auth = { group = "io.ktor", name = "ktor-client-auth", version.ref = "ktor" }
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
+ktor-client-apache = { group = "io.ktor", name = "ktor-client-apache5", version.ref = "ktor" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
@@ -111,7 +112,7 @@ database = ["database-exposed-core", "database-exposed-dao", "database-exposed-j
 documentation = ["ktor-server-swagger"]
 functional-programming = ["fp-arrow-core", "fp-arrow-core-high-arity", "fp-arrow-fx-coroutines"]
 ktor = ["ktor-server-core", "ktor-server-netty", "ktor-server-content-negotiation", "ktor-server-config-yaml", "ktor-client-core", "ktor-client-cio",
-  "ktor-client-content-negotiation", "ktor-client-logging", "ktor-server-status-pages", "ktor-client-auth","ktor-server-di"]
+  "ktor-client-apache", "ktor-client-content-negotiation", "ktor-client-logging", "ktor-server-status-pages", "ktor-client-auth","ktor-server-di"]
 logging = ["ktor-server-call-id", "ktor-server-call-logging", "logging-logback-classic", "logging-oshai-kotlin-logging"]
 monitoring = ["ktor-server-metrics-micrometer",
   "monitoring-micrometer-registry-prometheus",

--- a/src/main/kotlin/no/elhub/auth/features/common/CommonModule.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/CommonModule.kt
@@ -2,12 +2,11 @@ package no.elhub.auth.features.common
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.ProxyBuilder
+import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.engine.cio.CIO
-import io.ktor.client.engine.cio.endpoint
 import io.ktor.client.engine.http
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.LoggingFormat

--- a/src/main/kotlin/no/elhub/auth/features/common/CommonModule.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/CommonModule.kt
@@ -7,6 +7,7 @@ import io.ktor.client.engine.cio.endpoint
 import io.ktor.client.engine.http
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.LoggingFormat
@@ -51,13 +52,7 @@ fun Application.commonModule() {
             }
         }
         provide<HttpClient>(name = "pdpHttpClient") {
-            HttpClient(CIO) {
-                engine {
-                    maxConnectionsCount = 1000
-                    endpoint {
-                        maxConnectionsPerRoute = 300
-                    }
-                }
+            HttpClient(Apache5) {
                 install(HttpTimeout) {
                     requestTimeoutMillis = 10_000
                     connectTimeoutMillis = 10_000


### PR DESCRIPTION
Issues with high concurrency using CIO driver due to [this](https://youtrack.jetbrains.com/projects/KTOR/issues/KTOR-6503/CIO-client-engine-creates-new-TCP-connection-for-each-HTTP-requests).

Trying Apache5 now with the default `engine {}` block.