### PR TITLE
Remove unreachable check and fix unit test

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -44,10 +44,6 @@ class Handler(
             ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm.")
         }
 
-        ensure(document.signedBy == null) {
-            ConfirmError.IllegalStateError("AuthorizationDocument has already been signed.")
-        }
-
         ensure(document.validTo >= currentTimeUtc()) {
             ConfirmError.ExpiredError
         }

--- a/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.fail
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
@@ -256,7 +257,12 @@ class ExposedDocumentRepositoryTest :
                         listOf(AuthorizationDocument.Status.Pending)
                     )
                         .getOrElse { throw AssertionError("Repository read failed: $it") }
-                        .totalItems shouldBe numDocsPending
+                        .apply {
+                            totalItems shouldBe numDocsPending
+                            items.forAll {
+                                it.status shouldBe AuthorizationDocument.Status.Pending
+                            }
+                        }
 
                 val resultSigned =
                     repository.findAndSortByCreatedAt(
@@ -265,7 +271,12 @@ class ExposedDocumentRepositoryTest :
                         listOf(AuthorizationDocument.Status.Signed)
                     )
                         .getOrElse { throw AssertionError("Repository read failed: $it") }
-                        .totalItems shouldBe numDocsSigned
+                        .apply {
+                            totalItems shouldBe numDocsSigned
+                            items.forAll {
+                                it.status shouldBe AuthorizationDocument.Status.Signed
+                            }
+                        }
 
                 val resultExpired =
                     repository.findAndSortByCreatedAt(
@@ -274,7 +285,12 @@ class ExposedDocumentRepositoryTest :
                         listOf(AuthorizationDocument.Status.Expired)
                     )
                         .getOrElse { throw AssertionError("Repository read failed: $it") }
-                        .totalItems shouldBe numDocsExpired
+                        .apply {
+                            totalItems shouldBe numDocsExpired
+                            items.forAll {
+                                it.status shouldBe AuthorizationDocument.Status.Expired
+                            }
+                        }
 
                 val resultPendingPlusExpired =
                     repository.findAndSortByCreatedAt(

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
@@ -185,7 +185,7 @@ class HandlerTest : FunSpec({
         val documentId = UUID.randomUUID()
         val document = createDocument(
             documentId = documentId,
-            status = AuthorizationDocument.Status.Pending,
+            status = AuthorizationDocument.Status.Signed,
             signedBy = AuthorizationParty("some-id", PartyType.Person),
         )
 
@@ -203,7 +203,7 @@ class HandlerTest : FunSpec({
             )
         )
 
-        result.shouldBeLeft(ConfirmError.IllegalStateError("AuthorizationDocument has already been signed."))
+        result.shouldBeLeft(ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm."))
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }


### PR DESCRIPTION
The state set up in the documents/confirm HandlerTest "returns IllegalStateError when document is already signed" is not really possible; repo returning doc with status 'Pending' but a non-null signatory. This gets mapped to status 'Signed' by the repo.

Changes:
- remove dead `ensure` block
- fix illegal state unit test to assert on the correct error message
- in another test case, add assertions that the correct document status is returned, not just total count