### PR TITLE
Improve query plan for selecting+sorting documents

### DIFF
--- a/db/tables/0031-authorization-document-indexes.sql
+++ b/db/tables/0031-authorization-document-indexes.sql
@@ -1,0 +1,3 @@
+--changeset elhub:31
+CREATE INDEX ON auth.authorization_document (requested_by, created_at DESC);
+CREATE INDEX ON auth.authorization_document (requested_from, created_at DESC);


### PR DESCRIPTION
Part 2/2 of https://elhub.atlassian.net/browse/TDX-1562

In `findAndSortByCreatedAt` in doc repo, one of the queries generated would be like this (example from a unit test):
```sql
SELECT
  auth.authorization_document.id,
  auth.authorization_document."type",
  auth.authorization_document.file,
  auth.authorization_document.status,
  auth.authorization_document.requested_by,
  auth.authorization_document.requested_from,
  auth.authorization_document.requested_to,
  auth.authorization_document.valid_to,
  auth.authorization_document.created_at,
  auth.authorization_document.updated_at
FROM
  auth.authorization_document
WHERE
  (
    auth.authorization_document.requested_by = '48513845-9ea5-41dc-8417-3e82ba8358b8'
  )
  OR (
    auth.authorization_document.requested_from = '48513845-9ea5-41dc-8417-3e82ba8358b8'
  )
ORDER BY
  auth.authorization_document.created_at DESC
LIMIT
  100

```

This would initially generate the query plan:
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                        QUERY PLAN                                                                        │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=17.86..17.87 rows=5 width=128)                                                                                                              │
│   ->  Sort  (cost=17.86..17.87 rows=5 width=128)                                                                                                         │
│         Sort Key: created_at DESC                                                                                                                        │
│         ->  Seq Scan on authorization_document  (cost=0.00..17.80 rows=5 width=128)                                                                      │
│               Filter: ((requested_by = '48513845-9ea5-41dc-8417-3e82ba8358b8'::uuid) OR (requested_from = '48513845-9ea5-41dc-8417-3e82ba8358b8'::uuid)) │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```

After adding the indexes this is improved to use index scan on the two new indexes, then performing bitmap OR:

```
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                           QUERY PLAN                                                                           │
├────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=16.89..16.90 rows=5 width=128)                                                                                                                    │
│   ->  Sort  (cost=16.89..16.90 rows=5 width=128)                                                                                                               │
│         Sort Key: created_at DESC                                                                                                                              │
│         ->  Bitmap Heap Scan on authorization_document  (cost=8.35..16.83 rows=5 width=128)                                                                    │
│               Recheck Cond: ((requested_by = '48513845-9ea5-41dc-8417-3e82ba8358b8'::uuid) OR (requested_from = '48513845-9ea5-41dc-8417-3e82ba8358b8'::uuid)) │
│               ->  BitmapOr  (cost=8.35..8.35 rows=5 width=0)                                                                                                   │
│                     ->  Bitmap Index Scan on authorization_document_requested_by_created_at_idx  (cost=0.00..4.17 rows=3 width=0)                              │
│                           Index Cond: (requested_by = '48513845-9ea5-41dc-8417-3e82ba8358b8'::uuid)                                                            │
│                     ->  Bitmap Index Scan on authorization_document_requested_from_created_at_idx  (cost=0.00..4.17 rows=3 width=0)                            │
│                           Index Cond: (requested_from = '48513845-9ea5-41dc-8417-3e82ba8358b8'::uuid)                                                          │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

The sort in this query plan is likely to change in test environments to an index scan as well due to higher data volume than what I have in my local Postgres container.

Similar treatment has previously been applied for the requests/query feature in [this PR](https://github.com/elhub/auth-grant-manager/pull/611)