### PR TITLE
fix: Drop requested_from column in signatories table and replace pkey

### DIFF
--- a/db/tables/0032-authorization-document-signatories-alter.sql
+++ b/db/tables/0032-authorization-document-signatories-alter.sql
@@ -1,0 +1,4 @@
+--changeset elhub:32
+ALTER TABLE auth.authorization_document_signatories DROP CONSTRAINT authorization_document_signatories_pkey;
+ALTER TABLE auth.authorization_document_signatories DROP COLUMN requested_from;
+ALTER TABLE auth.authorization_document_signatories ADD PRIMARY KEY (authorization_document_id);

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -159,10 +159,7 @@ class ExposedDocumentRepository(
 
             val signatory = SignatoriesTable
                 .select(listOf(SignatoriesTable.signedBy))
-                .where {
-                    (SignatoriesTable.authorizationDocumentId eq id) and
-                        (SignatoriesTable.requestedFrom eq documentRow[AuthorizationDocumentTable.requestedFrom])
-                }
+                .where { (SignatoriesTable.authorizationDocumentId eq id) }
                 .singleOrNull()
                 ?.let { resolveParty(it[SignatoriesTable.signedBy]).bind() }
 
@@ -196,7 +193,6 @@ class ExposedDocumentRepository(
 
             SignatoriesTable.insert {
                 it[authorizationDocumentId] = documentId
-                it[this.requestedFrom] = requestedFromRecord.id
                 it[signedBy] = signatoryRecord.id
             }
 
@@ -426,13 +422,11 @@ object AuthorizationDocumentScopeTable : Table("auth.authorization_document_scop
 object SignatoriesTable : Table("auth.authorization_document_signatories") {
     val authorizationDocumentId = javaUUID("authorization_document_id")
         .references(AuthorizationDocumentTable.id, onDelete = ReferenceOption.CASCADE)
-    val requestedFrom = javaUUID("requested_from")
-        .references(AuthorizationPartyTable.id)
     val signedBy = javaUUID("signed_by")
         .references(AuthorizationPartyTable.id)
     val signedAt = timestampWithTimeZone("signed_at").clientDefault { currentTimeUtc() }
 
-    override val primaryKey = PrimaryKey(authorizationDocumentId, requestedFrom)
+    override val primaryKey = PrimaryKey(authorizationDocumentId)
 }
 
 fun ResultRow.toAuthorizationDocument(

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -77,7 +77,6 @@ interface DocumentRepository {
     suspend fun confirmWithGrant(
         documentId: UUID,
         signedFile: ByteArray,
-        requestedFrom: AuthorizationParty,
         signatory: AuthorizationParty,
         grant: AuthorizationGrant,
         grantProperties: List<AuthorizationGrantProperty>
@@ -175,7 +174,6 @@ class ExposedDocumentRepository(
     private suspend fun confirm(
         documentId: UUID,
         signedFile: ByteArray,
-        requestedFrom: AuthorizationParty,
         signatory: AuthorizationParty
     ): Either<RepositoryWriteError, AuthorizationDocument> =
         transactionContext<RepositoryWriteError, AuthorizationDocument>(
@@ -185,9 +183,6 @@ class ExposedDocumentRepository(
             { RepositoryWriteError.UnexpectedError }
         ) {
             val signatoryRecord = partyRepo.findOrInsert(signatory.type, signatory.id)
-                .mapLeft { RepositoryWriteError.UnexpectedError }
-                .bind()
-            val requestedFromRecord = partyRepo.findOrInsert(requestedFrom.type, requestedFrom.id)
                 .mapLeft { RepositoryWriteError.UnexpectedError }
                 .bind()
 
@@ -346,7 +341,6 @@ class ExposedDocumentRepository(
     override suspend fun confirmWithGrant(
         documentId: UUID,
         signedFile: ByteArray,
-        requestedFrom: AuthorizationParty,
         signatory: AuthorizationParty,
         grant: AuthorizationGrant,
         grantProperties: List<AuthorizationGrantProperty>
@@ -357,7 +351,7 @@ class ExposedDocumentRepository(
             "confirmWithGrant",
             { ConfirmWithGrantError.DocumentError.Unexpected }
         ) {
-            val confirmedDocument = confirm(documentId, signedFile, requestedFrom, signatory)
+            val confirmedDocument = confirm(documentId, signedFile, signatory)
                 .mapLeft { writeError ->
                     when (writeError) {
                         is RepositoryWriteError.NotFoundError -> ConfirmWithGrantError.DocumentError.NotFound

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -97,7 +97,6 @@ class Handler(
         val confirmedDocument = documentRepository.confirmWithGrant(
             documentId = document.id,
             signedFile = command.signedFile,
-            requestedFrom = document.requestedFrom,
             signatory = expectedSignatoryParty,
             grant = grantToCreate,
             grantProperties = grantMetaProperties

--- a/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/common/ExposedDocumentRepositoryTest.kt
@@ -243,7 +243,6 @@ class ExposedDocumentRepositoryTest :
                     repository.confirmWithGrant(
                         documentId = doc.id,
                         signedFile = "signed".toByteArray(),
-                        requestedFrom = party,
                         signatory = party,
                         grant = grant,
                         grantProperties = grantProperties,
@@ -430,7 +429,6 @@ class ExposedDocumentRepositoryTest :
                 val result = repository.confirmWithGrant(
                     documentId = document.id,
                     signedFile = "signed".toByteArray(),
-                    requestedFrom = requestedFrom,
                     signatory = signatory,
                     grant = grant,
                     grantProperties = grantProperties,

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
@@ -101,7 +101,7 @@ class HandlerTest : FunSpec({
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { partyService.resolve(any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns DocumentReadError when repository read fails") {
@@ -125,7 +125,7 @@ class HandlerTest : FunSpec({
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { partyService.resolve(any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns InvalidRequestedByError when authorizedParty does not match") {
@@ -150,7 +150,7 @@ class HandlerTest : FunSpec({
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { partyService.resolve(any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns IllegalStateError when document is not pending") {
@@ -178,7 +178,7 @@ class HandlerTest : FunSpec({
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns IllegalStateError when document is already signed") {
@@ -207,7 +207,7 @@ class HandlerTest : FunSpec({
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns ExpiredError when document validity period has passed") {
@@ -236,7 +236,7 @@ class HandlerTest : FunSpec({
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns ValidateSignaturesError when signature validation fails") {
@@ -265,7 +265,7 @@ class HandlerTest : FunSpec({
         verify(exactly = 1) { signatureService.validateSignaturesAndReturnSignatory(signedFile, document.file) }
         coVerify(exactly = 0) { partyService.resolve(any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns RequestedByResolutionError when signatory cannot be resolved") {
@@ -293,7 +293,7 @@ class HandlerTest : FunSpec({
         verify(exactly = 1) { signatureService.validateSignaturesAndReturnSignatory(signedFile, document.file) }
         coVerify(exactly = 1) { partyService.resolve(signatoryIdentifier) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns SignatoryNotAllowedToSignDocument when signatory differs from requestedTo") {
@@ -324,7 +324,7 @@ class HandlerTest : FunSpec({
         verify(exactly = 1) { signatureService.validateSignaturesAndReturnSignatory(signedFile, document.file) }
         coVerify(exactly = 1) { partyService.resolve(signatoryIdentifier) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns ScopeReadError when scope lookup fails") {
@@ -351,7 +351,7 @@ class HandlerTest : FunSpec({
 
         result.shouldBeLeft(ConfirmError.ScopeReadError)
         coVerify(exactly = 1) { documentRepository.findScopeIds(documentId) }
-        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
     test("returns DocumentNotFoundError when confirmWithGrant reports document not found") {
@@ -373,7 +373,7 @@ class HandlerTest : FunSpec({
         coEvery { partyService.resolve(signatoryIdentifier) } returns requestedTo.right()
         coEvery { documentRepository.findScopeIds(documentId) } returns listOf(scopeId).right()
         coEvery {
-            documentRepository.confirmWithGrant(documentId, signedFile, requestedFrom, requestedTo, any(), any())
+            documentRepository.confirmWithGrant(documentId, signedFile, requestedTo, any(), any())
         } returns ConfirmWithGrantError.DocumentError.NotFound.left()
 
         val result = handler(documentRepository, partyService, signatureService)(
@@ -382,7 +382,7 @@ class HandlerTest : FunSpec({
 
         result.shouldBeLeft(ConfirmError.DocumentNotFoundError)
         coVerify(exactly = 1) {
-            documentRepository.confirmWithGrant(documentId, signedFile, requestedFrom, requestedTo, any(), any())
+            documentRepository.confirmWithGrant(documentId, signedFile, requestedTo, any(), any())
         }
     }
 
@@ -405,7 +405,7 @@ class HandlerTest : FunSpec({
         coEvery { partyService.resolve(signatoryIdentifier) } returns requestedTo.right()
         coEvery { documentRepository.findScopeIds(documentId) } returns listOf(scopeId).right()
         coEvery {
-            documentRepository.confirmWithGrant(documentId, signedFile, requestedFrom, requestedTo, any(), any())
+            documentRepository.confirmWithGrant(documentId, signedFile, requestedTo, any(), any())
         } returns ConfirmWithGrantError.DocumentError.Conflict.left()
 
         val result = handler(documentRepository, partyService, signatureService)(
@@ -414,7 +414,7 @@ class HandlerTest : FunSpec({
 
         result.shouldBeLeft(ConfirmError.DocumentUpdateError)
         coVerify(exactly = 1) {
-            documentRepository.confirmWithGrant(documentId, signedFile, requestedFrom, requestedTo, any(), any())
+            documentRepository.confirmWithGrant(documentId, signedFile, requestedTo, any(), any())
         }
     }
 
@@ -437,7 +437,7 @@ class HandlerTest : FunSpec({
         coEvery { partyService.resolve(signatoryIdentifier) } returns requestedTo.right()
         coEvery { documentRepository.findScopeIds(documentId) } returns listOf(scopeId).right()
         coEvery {
-            documentRepository.confirmWithGrant(documentId, signedFile, requestedFrom, requestedTo, any(), any())
+            documentRepository.confirmWithGrant(documentId, signedFile, requestedTo, any(), any())
         } returns ConfirmWithGrantError.GrantError.left()
 
         val result = handler(documentRepository, partyService, signatureService)(
@@ -446,7 +446,7 @@ class HandlerTest : FunSpec({
 
         result.shouldBeLeft(ConfirmError.GrantCreationError)
         coVerify(exactly = 1) {
-            documentRepository.confirmWithGrant(documentId, signedFile, requestedFrom, requestedTo, any(), any())
+            documentRepository.confirmWithGrant(documentId, signedFile, requestedTo, any(), any())
         }
     }
 
@@ -475,7 +475,6 @@ class HandlerTest : FunSpec({
             documentRepository.confirmWithGrant(
                 documentId,
                 signedFile,
-                requestedFrom,
                 requestedTo,
                 any(),
                 any(),
@@ -492,7 +491,6 @@ class HandlerTest : FunSpec({
             documentRepository.confirmWithGrant(
                 documentId,
                 signedFile,
-                requestedFrom,
                 requestedTo,
                 match { grant ->
                     grant.grantedFor == document.requestedFrom &&

--- a/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
@@ -261,9 +261,6 @@ private suspend fun validateCreateDocumentResponse(response: HttpResponse, creat
 
             validTo shouldBe defaultValidTo
 
-            println(createdAt)
-            println(currentTimeOslo())
-            println(updatedAt)
             (Duration.between(createdAt, currentTimeOslo()).abs() < nowTolerance).shouldBeTrue()
             (Duration.between(updatedAt, currentTimeOslo()).abs() < nowTolerance).shouldBeTrue()
         }


### PR DESCRIPTION
https://elhub.atlassian.net/browse/TDX-1529

The column is redundant considering the document already has a `requested_from`. Support for multiple signatories would require changing the document model.

Composite pkey on (doc id, requested_from) is replaced with (doc id).