### PR TITLE
refactor: decouple identity resolution from authorization policy in AuthProvider

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/common/auth/AuthProvider.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/auth/AuthProvider.kt
@@ -44,11 +44,7 @@ enum class TokenType(val value: String) {
 }
 
 interface AuthorizationProvider {
-    suspend fun authorizeAll(call: ApplicationCall): Either<AuthError, AuthorizationParty>
-    suspend fun authorizeEndUserOrMaskinporten(call: ApplicationCall): Either<AuthError, AuthorizationParty>
-    suspend fun authorizeMaskinporten(call: ApplicationCall): Either<AuthError, AuthorizationParty>
-    suspend fun authorizeEndUser(call: ApplicationCall): Either<AuthError, AuthorizationParty>
-    suspend fun authorizeElhubService(call: ApplicationCall): Either<AuthError, AuthorizationParty>
+    suspend fun authorize(call: ApplicationCall): Either<AuthError, AuthorizationParty>
 }
 
 class PDPAuthorizationProvider(
@@ -71,81 +67,22 @@ class PDPAuthorizationProvider(
         }
     }
 
-    override suspend fun authorizeAll(call: ApplicationCall): Either<AuthError, AuthorizationParty> = either {
+    override suspend fun authorize(call: ApplicationCall): Either<AuthError, AuthorizationParty> = either {
         val traceId = resolveTraceId(call)
         val pdpBody: PdpResponse = pdpRequestAndValidate(call, traceId).bind()
 
         when (pdpBody.result.tokenInfo.tokenType) {
-            TokenType.MASKINPORTEN.value -> {
-                authorizeMaskinporten(call, pdpBody, traceId).bind()
-            }
+            TokenType.MASKINPORTEN.value -> authorizeMaskinporten(call, pdpBody).bind()
 
-            TokenType.ENDUSER.value -> {
-                authorizeEndUser(pdpBody, traceId).bind()
-            }
+            TokenType.ENDUSER.value -> authorizeEndUser(pdpBody).bind()
 
-            TokenType.ELHUB_SERVICE.value -> {
-                authorizeSystem(pdpBody, traceId).bind()
-            }
+            TokenType.ELHUB_SERVICE.value -> authorizeSystem(pdpBody).bind()
 
             else -> {
-                log.warn(
-                    "Unexpected tokenType for traceId={} tokenType={}",
-                    traceId,
-                    pdpBody.result.tokenInfo.tokenType
-                )
+                log.warn("Unexpected tokenType={}", pdpBody.result.tokenInfo.tokenType)
                 raise(AuthError.InvalidToken)
             }
         }
-    }
-
-    override suspend fun authorizeEndUserOrMaskinporten(call: ApplicationCall): Either<AuthError, AuthorizationParty> =
-        either {
-            val traceId = resolveTraceId(call)
-            val pdpBody: PdpResponse = pdpRequestAndValidate(call, traceId).bind()
-
-            when (pdpBody.result.tokenInfo.tokenType) {
-                TokenType.MASKINPORTEN.value -> {
-                    authorizeMaskinporten(call, pdpBody, traceId).bind()
-                }
-
-                TokenType.ENDUSER.value -> {
-                    authorizeEndUser(pdpBody, traceId).bind()
-                }
-
-                else -> {
-                    log.warn(
-                        "Unexpected tokenType for traceId={} tokenType={}",
-                        traceId,
-                        pdpBody.result.tokenInfo.tokenType
-                    )
-                    raise(AuthError.InvalidToken)
-                }
-            }
-        }
-
-    override suspend fun authorizeMaskinporten(call: ApplicationCall): Either<AuthError, AuthorizationParty> = either {
-        val traceId = resolveTraceId(call)
-        val pdpBody: PdpResponse = pdpRequestAndValidate(call, traceId).bind()
-        authorizeMaskinporten(call, pdpBody, traceId).bind()
-    }
-
-    override suspend fun authorizeEndUser(call: ApplicationCall): Either<AuthError, AuthorizationParty> = either {
-        val traceId = resolveTraceId(call)
-        val pdpBody: PdpResponse = pdpRequestAndValidate(call, traceId).bind()
-
-        if (pdpBody.result.tokenInfo.tokenType == TokenType.ENDUSER.value) {
-            authorizeEndUser(pdpBody, traceId).bind()
-        } else {
-            log.warn("Unexpected tokenType for traceId={} tokenType={}", traceId, pdpBody.result.tokenInfo.tokenType)
-            raise(AuthError.ActingFunctionNotSupported)
-        }
-    }
-
-    override suspend fun authorizeElhubService(call: ApplicationCall): Either<AuthError, AuthorizationParty> = either {
-        val traceId = resolveTraceId(call)
-        val pdpResponse = pdpRequestAndValidate(call, traceId).bind()
-        authorizeSystem(pdpResponse, traceId).bind()
     }
 
     private suspend fun pdpRequestAndValidate(call: ApplicationCall, traceId: UUID): Either<AuthError, PdpResponse> =
@@ -185,7 +122,7 @@ class PDPAuthorizationProvider(
                     setBody(request)
                 }
             }.mapLeft {
-                log.error("PDP request failed for traceId={}", traceId, it)
+                log.error("PDP request failed", it)
                 raise(AuthError.UnexpectedPdpError)
             }.bind()
 
@@ -193,17 +130,13 @@ class PDPAuthorizationProvider(
                 response.status.isSuccess() -> Either.catch {
                     response.body<PdpResponse>()
                 }.getOrElse {
-                    log.error(
-                        "Failed to deserialize PDP response for traceId={}, response={}",
-                        traceId,
-                        response.bodyAsText()
-                    )
+                    log.error("Failed to deserialize PDP response response={}", response.bodyAsText())
                     raise(AuthError.UnexpectedPdpError)
                 }
 
                 else -> {
                     val err = response.bodyAsText()
-                    log.warn("PDP non-2xx for traceId={} status={} body={}", traceId, response.status, err)
+                    log.warn("PDP non-2xx status={} body={}", response.status, err)
                     raise(AuthError.UnexpectedPdpError)
                 }
             }
@@ -211,7 +144,7 @@ class PDPAuthorizationProvider(
             val tokenInfo = pdpBody.result.tokenInfo
             val status = tokenInfo.tokenStatus
             if (status != "verified") {
-                log.warn("Invalid token status for traceId={} status={}", traceId, status)
+                log.warn("Invalid token status={}", status)
                 raise(AuthError.InvalidToken)
             }
             pdpBody
@@ -220,34 +153,25 @@ class PDPAuthorizationProvider(
     private fun authorizeMaskinporten(
         call: ApplicationCall,
         pdpBody: PdpResponse,
-        traceId: UUID
     ): Either<AuthError, AuthorizationParty> = either {
-        val tokenInfo = pdpBody.result.tokenInfo
-        if (!TokenType.MASKINPORTEN.value.equals(tokenInfo.tokenType)) {
-            raise(AuthError.AccessDenied)
-        }
         call.request.headers[Headers.SENDER_GLN] ?: raise(AuthError.MissingSenderGlnHeader)
         val authInfo = pdpBody.result.authInfo ?: raise(AuthError.InvalidPdpResponseAuthInfoMissing)
         if (authInfo.inputFailed != null) {
-            log.error("PDP input validation failed for traceId={} msg={}", traceId, authInfo.inputFailed)
+            log.error("PDP input validation failed msg={}", authInfo.inputFailed)
             raise(AuthError.AccessDenied)
         }
         val actingGLN = authInfo.actingGLN ?: raise(AuthError.InvalidPdpResponseActingGlnMissing)
         val authorizedFunctions = authInfo.authorizedFunctions
             ?.takeIf { it.isNotEmpty() }
             ?: run {
-                log.warn("PDP response missing authorizedFunctions for traceId={}", traceId)
+                log.warn("PDP response missing authorizedFunctions")
                 raise(AuthError.InvalidPdpResponseAuthorizedFunctionsMissing)
             }
 
         authorizedFunctions
             .firstOrNull { it.functionName == RoleType.BalanceSupplier.name }
             ?: run {
-                log.warn(
-                    "Unsupported authorizedFunctions for traceId={} authorizedFunctions={}",
-                    traceId,
-                    authorizedFunctions
-                )
+                log.warn("Unsupported authorizedFunctions={}", authorizedFunctions)
                 raise(AuthError.ActingFunctionNotSupported)
             }
         val authorizedParty = AuthorizationParty(id = actingGLN, type = PartyType.OrganizationEntity)
@@ -257,13 +181,7 @@ class PDPAuthorizationProvider(
 
     private fun authorizeEndUser(
         pdpBody: PdpResponse,
-        traceId: UUID
     ): Either<AuthError, AuthorizationParty> = either {
-        val tokenInfo = pdpBody.result.tokenInfo
-        if (!TokenType.ENDUSER.value.equals(tokenInfo.tokenType)) {
-            log.warn("Unexpected tokenType for traceId={} tokenType={}", traceId, tokenInfo.tokenType)
-            raise(AuthError.AccessDenied)
-        }
         val authInfo = pdpBody.result.authInfo
         if (authInfo?.error != null) {
             log.warn("PDP authInfo error={}", authInfo.error)
@@ -290,14 +208,8 @@ class PDPAuthorizationProvider(
 
     private fun authorizeSystem(
         pdpResponse: PdpResponse,
-        traceId: UUID
     ): Either<AuthError, AuthorizationParty> = either {
-        val tokenInfo = pdpResponse.result.tokenInfo
-        if (!TokenType.ELHUB_SERVICE.value.equals(tokenInfo.tokenType)) {
-            log.warn("Unexpected tokenType for traceId={} tokenType={}", traceId, tokenInfo.tokenType)
-            raise(AuthError.AccessDenied)
-        }
-        val partyId = tokenInfo.partyId ?: raise(AuthError.UnexpectedPdpError)
+        val partyId = pdpResponse.result.tokenInfo.partyId ?: raise(AuthError.UnexpectedPdpError)
         val authorizedParty = AuthorizationParty(id = partyId, type = PartyType.System)
         log.info("Authorized party is $authorizedParty")
         authorizedParty

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/ConfirmError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/ConfirmError.kt
@@ -9,6 +9,7 @@ import no.elhub.devxp.jsonapi.response.JsonApiErrorCollection
 
 sealed class ConfirmError {
     data class ValidateSignaturesError(val cause: SignatureValidationError) : ConfirmError()
+    data object InvalidPartyTypeError : ConfirmError()
     data object SignatoryNotAllowedToSignDocument : ConfirmError()
     data object SignatoryResolutionError : ConfirmError()
     data object DocumentNotFoundError : ConfirmError()
@@ -25,6 +26,12 @@ sealed class ConfirmError {
 fun ConfirmError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection> =
     when (this) {
         ConfirmError.DocumentNotFoundError -> toNotFoundApiErrorResponse("AuthorizationDocument could not be found.")
+
+        ConfirmError.InvalidPartyTypeError -> buildApiErrorResponse(
+            status = HttpStatusCode.Forbidden,
+            title = "Party not authorized",
+            detail = "The authorized party is not permitted to perform this action.",
+        )
 
         is ConfirmError.ValidateSignaturesError -> handleValidateSignatureError(this)
 

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -6,6 +6,7 @@ import arrow.core.raise.ensure
 import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.currentTimeUtc
 import no.elhub.auth.features.common.party.PartyService
+import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.common.ConfirmWithGrantError
@@ -27,6 +28,10 @@ class Handler(
 
     suspend operator fun invoke(command: Command): Either<ConfirmError, Unit> = either {
         val authorizationParty = command.authorizedParty
+
+        ensure(authorizationParty.type == PartyType.OrganizationEntity) {
+            ConfirmError.InvalidPartyTypeError
+        }
 
         val document = documentRepository.find(command.documentId)
             .mapLeft { error ->

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Route.kt
@@ -29,7 +29,7 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
             return@put
         }
 
-        val resolvedActor = authProvider.authorizeMaskinporten(call)
+        val resolvedActor = authProvider.authorize(call)
             .getOrElse {
                 val error = it.toApiErrorResponse()
                 call.respond(error.first, error.second)

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/CreateError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/CreateError.kt
@@ -12,6 +12,7 @@ import no.elhub.devxp.jsonapi.response.JsonApiErrorCollection
 sealed class CreateError {
     data object FileGenerationError : CreateError()
     data class SignFileError(val cause: SignatureSigningError) : CreateError()
+    data object InvalidPartyTypeError : CreateError()
     data object MismatchBetweenAuthorizedPartyAndRequestedBy : CreateError()
     data object PersistenceError : CreateError()
     data object RequestedPartyError : CreateError()
@@ -21,6 +22,12 @@ sealed class CreateError {
 
 fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection> =
     when (this) {
+        is CreateError.InvalidPartyTypeError -> buildApiErrorResponse(
+            status = HttpStatusCode.Forbidden,
+            title = "Party not authorized",
+            detail = "The authorized party is not permitted to perform this action.",
+        )
+
         is CreateError.MismatchBetweenAuthorizedPartyAndRequestedBy -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
             title = "Party not authorized",

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/Handler.kt
@@ -5,6 +5,7 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import no.elhub.auth.features.common.party.PartyError
 import no.elhub.auth.features.common.party.PartyService
+import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.documents.AuthorizationDocument
 import no.elhub.auth.features.documents.common.AuthorizationDocumentProperty
 import no.elhub.auth.features.documents.common.CreateDocumentBusinessModel
@@ -26,6 +27,10 @@ class Handler(
     suspend operator fun invoke(model: CreateDocumentModel): Either<CreateError, AuthorizationDocument> =
         either {
             logger.info("event=authorization_document_creation type=${model.documentType}")
+
+            ensure(model.authorizedParty.type == PartyType.OrganizationEntity) {
+                CreateError.InvalidPartyTypeError
+            }
 
             val requestedByParty =
                 partyService

--- a/src/main/kotlin/no/elhub/auth/features/documents/create/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/create/Route.kt
@@ -22,7 +22,7 @@ fun Route.route(
     authProvider: AuthorizationProvider,
 ) {
     post {
-        val resolvedActor = authProvider.authorizeMaskinporten(call)
+        val resolvedActor = authProvider.authorize(call)
             .getOrElse {
                 val error = it.toApiErrorResponse()
                 call.respond(error.first, error.second)

--- a/src/main/kotlin/no/elhub/auth/features/documents/get/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/get/Route.kt
@@ -22,7 +22,7 @@ private val logger = LoggerFactory.getLogger(Route::class.java)
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get("/{$DOCUMENT_ID_PARAM}") {
-        val authorizedParty = authProvider.authorizeEndUserOrMaskinporten(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)
@@ -64,7 +64,7 @@ fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
             return@get
         }
 
-        val authorizedParty = authProvider.authorizeEndUserOrMaskinporten(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/documents/query/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/query/Route.kt
@@ -19,7 +19,7 @@ private const val STATUS_FILTER_PARAM = "filter[status]"
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get {
-        val authorizedParty = authProvider.authorizeEndUserOrMaskinporten(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/grants/consume/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/consume/Route.kt
@@ -22,7 +22,7 @@ const val GRANT_ID_PARAM = "id"
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     patch("/{$GRANT_ID_PARAM}") {
-        val authorizedSystem = authProvider.authorizeElhubService(call)
+        val authorizedSystem = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/grants/get/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/get/Route.kt
@@ -18,7 +18,7 @@ private val logger = LoggerFactory.getLogger(Route::class.java)
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get("/{$GRANT_ID_PARAM}") {
-        val authorizedParty = authProvider.authorizeAll(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/grants/getscopes/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/getscopes/Route.kt
@@ -18,7 +18,7 @@ const val GRANT_ID_PARAM = "id"
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get("/{$GRANT_ID_PARAM}/scopes") {
-        val authorizedParty = authProvider.authorizeAll(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/grants/query/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/query/Route.kt
@@ -16,7 +16,7 @@ private val logger = LoggerFactory.getLogger(Route::class.java)
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get {
-        val authorizedParty = authProvider.authorizeEndUserOrMaskinporten(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/CreateError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/CreateError.kt
@@ -10,6 +10,7 @@ import no.elhub.devxp.jsonapi.response.JsonApiErrorCollection
 
 sealed class CreateError {
     data object MappingError : CreateError()
+    data object InvalidPartyTypeError : CreateError()
     data object AuthorizationError : CreateError()
     data object PersistenceError : CreateError()
     data object RequestedPartyError : CreateError()
@@ -19,6 +20,12 @@ sealed class CreateError {
 
 fun CreateError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection> =
     when (this) {
+        CreateError.InvalidPartyTypeError -> buildApiErrorResponse(
+            status = HttpStatusCode.Forbidden,
+            title = "Party not authorized",
+            detail = "The authorized party is not permitted to perform this action.",
+        )
+
         CreateError.AuthorizationError -> buildApiErrorResponse(
             status = HttpStatusCode.Forbidden,
             title = "Party not authorized",

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/Handler.kt
@@ -5,6 +5,7 @@ import arrow.core.raise.either
 import arrow.core.raise.ensure
 import no.elhub.auth.features.common.party.PartyError
 import no.elhub.auth.features.common.party.PartyService
+import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.requests.AuthorizationRequest
 import no.elhub.auth.features.requests.common.AuthorizationRequestProperty
 import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
@@ -22,6 +23,11 @@ class Handler(
 
     suspend operator fun invoke(model: CreateRequestModel): Either<CreateError, AuthorizationRequest> = either {
         logger.info("event=authorization_request_creation type=${model.requestType}")
+
+        ensure(model.authorizedParty.type == PartyType.OrganizationEntity) {
+            CreateError.InvalidPartyTypeError
+        }
+
         val requestedByParty =
             partyService
                 .resolve(model.coreMeta.requestedBy)

--- a/src/main/kotlin/no/elhub/auth/features/requests/create/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/create/Route.kt
@@ -22,9 +22,9 @@ fun Route.route(
     authProvider: AuthorizationProvider
 ) {
     post {
-        val resolvedActor = authProvider.authorizeMaskinporten(call)
+        val resolvedActor = authProvider.authorize(call)
             .getOrElse {
-                logger.error("Failed to authorize Maskinporten token for POST /authorization-requests: {}", it)
+                logger.error("Failed to authorize token for POST /authorization-requests: {}", it)
                 val error = it.toApiErrorResponse()
                 call.respond(error.first, error.second)
                 return@post

--- a/src/main/kotlin/no/elhub/auth/features/requests/get/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/get/Route.kt
@@ -18,7 +18,7 @@ private val logger = LoggerFactory.getLogger(Route::class.java)
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get("/{$REQUEST_ID_PARAM}") {
-        val authorizedParty = authProvider.authorizeEndUserOrMaskinporten(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/requests/query/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/query/Route.kt
@@ -19,7 +19,7 @@ private const val STATUS_FILTER_PARAM = "filter[status]"
 
 fun Route.route(handler: Handler, authProvider: AuthorizationProvider) {
     get {
-        val authorizedParty = authProvider.authorizeEndUserOrMaskinporten(call)
+        val authorizedParty = authProvider.authorize(call)
             .getOrElse { err ->
                 val (status, body) = err.toApiErrorResponse()
                 call.respond(status, body)

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
@@ -37,7 +37,7 @@ class Handler(
         when (command.newStatus) {
             AuthorizationRequest.Status.Accepted -> handleAccepted(request, command).bind()
             AuthorizationRequest.Status.Rejected -> handleRejected(request).bind()
-            else -> raise(UpdateError.IllegalTransitionError) // consumers can only send Accepted and Rejected statuses
+            else -> raise(UpdateError.IllegalTransitionError)
         }
     }
 

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Route.kt
@@ -24,7 +24,7 @@ fun Route.route(
     authProvider: AuthorizationProvider
 ) {
     patch("/{$REQUEST_ID_PARAM}") {
-        val resolvedActor = authProvider.authorizeEndUser(call)
+        val resolvedActor = authProvider.authorize(call)
             .getOrElse {
                 val error = it.toApiErrorResponse()
                 call.respond(error.first, error.second)

--- a/src/test/kotlin/no/elhub/auth/features/common/auth/PDPAuthorizationProviderTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/common/auth/PDPAuthorizationProviderTest.kt
@@ -36,213 +36,91 @@ val validHeadersForMaskinporten = headersOf(
 
 class PDPAuthorizationProviderTest : FunSpec({
 
-    context("authorizeEndUserOrMaskinporten") {
-        test("returns AuthorizationParty when PDP reports maskinporten token") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUserOrMaskinporten,
+    context("authorize") {
+
+        // --- Common header validation ---
+
+        test("returns MissingAuthorizationHeader when authorization header is missing") {
+            val response = runAuthorize(headers = Headers.Empty)
+            response.shouldBeLeft(AuthError.MissingAuthorizationHeader)
+        }
+
+        test("returns InvalidAuthorizationHeader when authorization header format is invalid") {
+            val response = runAuthorize(
+                headers = headersOf(HttpHeaders.Authorization to listOf(TOKEN_INVALID_FORMAT))
+            )
+            response.shouldBeLeft(AuthError.InvalidAuthorizationHeader)
+        }
+
+        test("returns InvalidToken when tokenStatus is not verified") {
+            val response = runAuthorize(
                 headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse()
-                )
+                responseBody = json.encodeToString(maskinportenResponse(tokenStatus = "wrong"))
             )
-
-            response.shouldBeRight(
-                AuthorizationParty(id = "0107000000021", type = PartyType.OrganizationEntity)
-            )
-        }
-
-        test("returns AccessDenied when PDP reports enduser token without valid actingType") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUserOrMaskinporten,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse()
-                )
-            )
-
-            response.shouldBeLeft(AuthError.AccessDenied)
-        }
-
-        test("returns InvalidToken for unsupported tokenType") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUserOrMaskinporten,
-                headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse(tokenType = "unknown")
-                )
-            )
-
-            response.shouldBeLeft(AuthError.InvalidToken)
-        }
-    }
-
-    context("authorizeAll") {
-        test("returns AuthorizationParty when PDP reports maskinporten token") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeAll,
-                headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse()
-                )
-            )
-
-            response.shouldBeRight(
-                AuthorizationParty(id = "0107000000021", type = PartyType.OrganizationEntity)
-            )
-        }
-
-        test("returns AccessDenied when PDP reports enduser token without valid actingType") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeAll,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse()
-                )
-            )
-
-            response.shouldBeLeft(AuthError.AccessDenied)
-        }
-
-        test("returns AuthorizationParty when PDP reports elhub-service token") {
-            val partyId = "system-123"
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeAll,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    elhubServiceResponse(partyId = partyId)
-                )
-            )
-
-            response.shouldBeRight(AuthorizationParty(id = partyId, type = PartyType.System))
-        }
-
-        test("returns InvalidToken for unsupported tokenType") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeAll,
-                headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse(tokenType = "unknown")
-                )
-            )
-
             response.shouldBeLeft(AuthError.InvalidToken)
         }
 
-        test("returns UnexpectedPdpError when PDP response is not valid PdpResponse") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
+        test("returns InvalidToken for unsupported tokenType") {
+            val response = runAuthorize(
+                headers = validHeadersForMaskinporten,
+                responseBody = json.encodeToString(maskinportenResponse(tokenType = "unknown"))
+            )
+            response.shouldBeLeft(AuthError.InvalidToken)
+        }
+
+        test("returns UnexpectedPdpError when PDP response is not valid") {
+            val response = runAuthorize(
                 headers = validHeadersForMaskinporten,
                 responseBody = """{"not": "a valid pdp response"}"""
             )
             response.shouldBeLeft(AuthError.UnexpectedPdpError)
         }
-    }
 
-    context("authorizeMaskinporten") {
-        test("returns MissingAuthorizationHeader when authorization header is missing") {
+        // --- Maskinporten token ---
 
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
-                headers = Headers.Empty
+        test("returns AuthorizationParty(OrganizationEntity) for valid maskinporten token") {
+            val response = runAuthorize(
+                headers = validHeadersForMaskinporten,
+                responseBody = json.encodeToString(maskinportenResponse())
             )
-
-            response.shouldBeLeft(AuthError.MissingAuthorizationHeader)
+            response.shouldBeRight(AuthorizationParty(id = "0107000000021", type = PartyType.OrganizationEntity))
         }
 
-        test("returns InvalidAuthorizationHeader when authorization header format is invalid") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
-                headersOf(
-                    HttpHeaders.Authorization to listOf(TOKEN_INVALID_FORMAT),
-                )
-            )
-
-            response.shouldBeLeft(AuthError.InvalidAuthorizationHeader)
-        }
-
-        test("returns MissingSenderGlnHeader when senderGLN header is missing") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
+        test("returns MissingSenderGlnHeader when senderGLN header is missing for maskinporten token") {
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
                 responseBody = json.encodeToString(
                     maskinportenResponse(
                         authInfo = AuthInfo(
                             authorizedFunctions = listOf(
-                                AuthorizedFunction(
-                                    functionCode = "SELF",
-                                    functionName = RoleType.BalanceSupplier.name
-                                )
+                                AuthorizedFunction(functionCode = "SELF", functionName = RoleType.BalanceSupplier.name)
                             ),
                             actingGLN = "0107000000021"
                         )
                     )
                 )
             )
-
             response.shouldBeLeft(AuthError.MissingSenderGlnHeader)
         }
 
-        test("returns InvalidToken when tokenStatus is not verified") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
+        test("returns AccessDenied when maskinporten PDP response includes inputFailed") {
+            val response = runAuthorize(
                 headers = validHeadersForMaskinporten,
                 responseBody = json.encodeToString(
-                    maskinportenResponse(tokenStatus = "wrong")
+                    maskinportenResponse(authInfo = AuthInfo(inputFailed = "some missing stuff"))
                 )
             )
-            response.shouldBeLeft(AuthError.InvalidToken)
-        }
-
-        test("returns Forbidden when tokenType is not maskinporten") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
-                headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse(tokenType = "random")
-                )
-            )
-
             response.shouldBeLeft(AuthError.AccessDenied)
         }
 
-        test("returns AuthorizationParty for authorized maskinporten decision") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
-                headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse()
-                )
-            )
-            response.shouldBeRight(AuthorizationParty(id = "0107000000021", type = PartyType.OrganizationEntity))
-        }
-
-        test("returns InvalidPdpResponseActingFunctionMissing when PDP response lacks authorizedFunctions") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
-                headers = validHeadersForMaskinporten,
-                responseBody = json.encodeToString(
-                    maskinportenResponse(
-                        authInfo = AuthInfo(
-                            authorizedFunctions = null,
-                            actingGLN = "0107000000021"
-                        )
-                    )
-                )
-            )
-            response.shouldBeLeft(AuthError.InvalidPdpResponseAuthorizedFunctionsMissing)
-        }
-        test("returns InvalidPdpResponseActingGlnMissing when PDP response lacks actingGln") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
+        test("returns InvalidPdpResponseActingGlnMissing when maskinporten response lacks actingGLN") {
+            val response = runAuthorize(
                 headers = validHeadersForMaskinporten,
                 responseBody = json.encodeToString(
                     maskinportenResponse(
                         authInfo = AuthInfo(
                             authorizedFunctions = listOf(
-                                AuthorizedFunction(
-                                    functionCode = "SELF",
-                                    functionName = RoleType.BalanceSupplier.name
-                                )
+                                AuthorizedFunction(functionCode = "SELF", functionName = RoleType.BalanceSupplier.name)
                             ),
                             actingGLN = null
                         )
@@ -252,127 +130,51 @@ class PDPAuthorizationProviderTest : FunSpec({
             response.shouldBeLeft(AuthError.InvalidPdpResponseActingGlnMissing)
         }
 
-        test("returns Forbidden when PDP response includes input failed") {
-
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
+        test("returns InvalidPdpResponseAuthorizedFunctionsMissing when maskinporten response lacks authorizedFunctions") {
+            val response = runAuthorize(
                 headers = validHeadersForMaskinporten,
                 responseBody = json.encodeToString(
                     maskinportenResponse(
-                        authInfo = AuthInfo(
-                            inputFailed = "some missing stuff"
-                        )
+                        authInfo = AuthInfo(authorizedFunctions = null, actingGLN = "0107000000021")
                     )
                 )
             )
-            response.shouldBeLeft(AuthError.AccessDenied)
+            response.shouldBeLeft(AuthError.InvalidPdpResponseAuthorizedFunctionsMissing)
         }
 
-        test("returns ActingFunctionNotSupported when PDP response includes unsupported authorizedFunctions") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeMaskinporten,
+        test("returns ActingFunctionNotSupported when maskinporten authorizedFunctions contains no BalanceSupplier") {
+            val response = runAuthorize(
                 headers = validHeadersForMaskinporten,
                 responseBody = json.encodeToString(
                     maskinportenResponse(
                         authInfo = AuthInfo(
                             authorizedFunctions = listOf(
-                                AuthorizedFunction(
-                                    functionCode = "SELF",
-                                    functionName = "UnknownRole"
-                                )
+                                AuthorizedFunction(functionCode = "SELF", functionName = "UnknownRole")
                             ),
                             actingGLN = "0107000000021"
                         )
                     )
                 )
             )
-
-            response.shouldBeLeft(AuthError.ActingFunctionNotSupported)
-        }
-    }
-
-    context("authorizeEndUser") {
-
-        test("returns ActingFunctionNotSupported when tokenType is not enduser and has a valid token") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    maskinportenResponse()
-                )
-            )
-
             response.shouldBeLeft(AuthError.ActingFunctionNotSupported)
         }
 
-        test("returns InvalidToken when tokenType is not enduser and has a invalid tokenStatus") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    maskinportenResponse(tokenStatus = "wrong")
-                )
-            )
-            response.shouldBeLeft(AuthError.InvalidToken)
-        }
+        // --- EndUser token ---
 
-        test("returns AccessDenied when partyId is missing and actingType is not valid") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse(partyId = null)
-                )
-            )
-
-            response.shouldBeLeft(AuthError.AccessDenied)
-        }
-
-        test("returns AccessDenied when authInfo is missing even if partyId is present") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse()
-                )
-            )
-
-            response.shouldBeLeft(AuthError.AccessDenied)
-        }
-
-        test("returns AuthorizedPerson with actingId when authInfo contains actingType=person") {
+        test("returns AuthorizationParty(Person) for enduser token with actingType=person") {
             val actingId = "e76439bc-0344-4ef5-b2f8-41a72c25ffd8"
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
                 responseBody = json.encodeToString(
-                    endUserResponse(
-                        authInfo = AuthInfo(actingType = "person", actingId = actingId)
-                    )
+                    endUserResponse(authInfo = AuthInfo(actingType = "person", actingId = actingId))
                 )
             )
-
             response.shouldBeRight(AuthorizationParty(id = actingId, type = PartyType.Person))
         }
 
-        test("returns UnexpectedPdpError when authInfo.actingType is person but actingId is missing") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse(
-                        authInfo = AuthInfo(actingType = "person", actingId = null)
-                    )
-                )
-            )
-
-            response.shouldBeLeft(AuthError.UnexpectedPdpError)
-        }
-
-        test("returns AuthorizedOrganization when authInfo contains actingType=organisation") {
+        test("returns AuthorizationParty(Organization) for enduser token with actingType=organisation") {
             val orgNumber = "306137018"
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
                 responseBody = json.encodeToString(
                     endUserResponse(
@@ -384,27 +186,49 @@ class PDPAuthorizationProviderTest : FunSpec({
                     )
                 )
             )
-
             response.shouldBeRight(AuthorizationParty(id = orgNumber, type = PartyType.Organization))
         }
 
-        test("returns UnexpectedPdpError when authInfo.actingType is organisation but actingOrganisationNumber is missing") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
+        test("returns AccessDenied when enduser actingType is missing") {
+            val response = runAuthorize(
+                headers = authorizationOnlyHeaders(),
+                responseBody = json.encodeToString(endUserResponse())
+            )
+            response.shouldBeLeft(AuthError.AccessDenied)
+        }
+
+        test("returns AccessDenied when enduser actingType is blank without authInfo error") {
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
                 responseBody = json.encodeToString(
-                    endUserResponse(
-                        authInfo = AuthInfo(actingType = "organisation", actingOrganisationNumber = null)
-                    )
+                    endUserResponse(authInfo = AuthInfo(actingType = "", actingId = ""))
                 )
             )
+            response.shouldBeLeft(AuthError.AccessDenied)
+        }
 
+        test("returns UnexpectedPdpError when enduser actingType is person but actingId is missing") {
+            val response = runAuthorize(
+                headers = authorizationOnlyHeaders(),
+                responseBody = json.encodeToString(
+                    endUserResponse(authInfo = AuthInfo(actingType = "person", actingId = null))
+                )
+            )
             response.shouldBeLeft(AuthError.UnexpectedPdpError)
         }
 
-        test("returns OnBehalfOfOrganisationVerificationFailed when PDP authInfo contains error") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
+        test("returns UnexpectedPdpError when enduser actingType is organisation but actingOrganisationNumber is missing") {
+            val response = runAuthorize(
+                headers = authorizationOnlyHeaders(),
+                responseBody = json.encodeToString(
+                    endUserResponse(authInfo = AuthInfo(actingType = "organisation", actingOrganisationNumber = null))
+                )
+            )
+            response.shouldBeLeft(AuthError.UnexpectedPdpError)
+        }
+
+        test("returns EndUserOnBehalfOfOrganisationVerificationFailed when PDP authInfo contains error") {
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
                 responseBody = json.encodeToString(
                     endUserResponse(
@@ -416,13 +240,11 @@ class PDPAuthorizationProviderTest : FunSpec({
                     )
                 )
             )
-
             response.shouldBeLeft(AuthError.EndUserOnBehalfOfOrganisationVerificationFailed)
         }
 
-        test("deserializes blank actingType as null and returns verification error") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
+        test("deserializes blank actingType as null and returns EndUserOnBehalfOfOrganisationVerificationFailed") {
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
                 responseBody = """
                 {
@@ -443,64 +265,26 @@ class PDPAuthorizationProviderTest : FunSpec({
                 }
                 """.trimIndent()
             )
-
             response.shouldBeLeft(AuthError.EndUserOnBehalfOfOrganisationVerificationFailed)
         }
 
-        test("returns AccessDenied when actingType is blank without authInfo error") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeEndUser,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse(
-                        authInfo = AuthInfo(
-                            actingType = "",
-                            actingId = "",
-                        )
-                    )
-                )
-            )
+        // --- Elhub service token ---
 
-            response.shouldBeLeft(AuthError.AccessDenied)
-        }
-    }
-
-    context("authorizeElhubService") {
-        test("returns Forbidden when tokenType is not elhub-service") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeElhubService,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    endUserResponse()
-                )
-            )
-
-            response.shouldBeLeft(AuthError.AccessDenied)
-        }
-
-        test("returns UnexpectedPdpError when partyId is missing") {
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeElhubService,
-                headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    elhubServiceResponse(partyId = null)
-                )
-            )
-
-            response.shouldBeLeft(AuthError.UnexpectedPdpError)
-        }
-
-        test("returns AuthorizedSystem when partyId is present") {
+        test("returns AuthorizationParty(System) for valid elhub-service token") {
             val partyId = "system-123"
-            val response = runProviderMethod(
-                method = PDPAuthorizationProvider::authorizeElhubService,
+            val response = runAuthorize(
                 headers = authorizationOnlyHeaders(),
-                responseBody = json.encodeToString(
-                    elhubServiceResponse(partyId = partyId)
-                )
+                responseBody = json.encodeToString(elhubServiceResponse(partyId = partyId))
             )
-
             response.shouldBeRight(AuthorizationParty(id = partyId, type = PartyType.System))
+        }
+
+        test("returns UnexpectedPdpError when elhub-service token has no partyId") {
+            val response = runAuthorize(
+                headers = authorizationOnlyHeaders(),
+                responseBody = json.encodeToString(elhubServiceResponse(partyId = null))
+            )
+            response.shouldBeLeft(AuthError.UnexpectedPdpError)
         }
     }
 })
@@ -516,12 +300,11 @@ private fun mockCall(headers: Headers): ApplicationCall {
     return call
 }
 
-private suspend fun <T> runProviderMethod(
-    method: suspend PDPAuthorizationProvider.(ApplicationCall) -> Either<AuthError, T>,
+private suspend fun runAuthorize(
     headers: Headers,
     responseBody: String = json.encodeToString(maskinportenResponse()),
     status: HttpStatusCode = HttpStatusCode.OK
-): Either<AuthError, T> {
+): Either<AuthError, AuthorizationParty> {
     val client = HttpClient(
         MockEngine { _ ->
             respond(
@@ -544,7 +327,7 @@ private suspend fun <T> runProviderMethod(
         pdpBaseUrl = "http://mock.pdp"
     )
 
-    return provider.method(mockCall(headers))
+    return provider.authorize(mockCall(headers))
 }
 
 private fun authorizationOnlyHeaders(authorization: String = TOKEN_VALID_FORMAT) = headersOf(

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
@@ -80,6 +80,25 @@ class HandlerTest : FunSpec({
         signatureService = signatureService,
     )
 
+    test("returns InvalidPartyTypeError when authorized party is not an OrganizationEntity") {
+        val documentId = UUID.randomUUID()
+        val documentRepository = mockk<DocumentRepository>(relaxed = true)
+        val partyService = mockk<PartyService>(relaxed = true)
+        val signatureService = mockk<SignatureService>(relaxed = true)
+
+        val result = handler(documentRepository, partyService, signatureService)(
+            Command(
+                documentId = documentId,
+                authorizedParty = AuthorizationParty(id = "person-1", type = PartyType.Person),
+                signedFile = signedFile
+            )
+        )
+
+        result.shouldBeLeft(ConfirmError.InvalidPartyTypeError)
+        coVerify(exactly = 0) { documentRepository.find(any()) }
+        coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
+    }
+
     test("returns DocumentNotFoundError when document is missing") {
         val documentId = UUID.randomUUID()
         val documentRepository = mockk<DocumentRepository>()
@@ -140,7 +159,7 @@ class HandlerTest : FunSpec({
         val result = handler(documentRepository, partyService, signatureService)(
             Command(
                 documentId = documentId,
-                authorizedParty = AuthorizationParty(id = "different", type = PartyType.Person),
+                authorizedParty = AuthorizationParty(id = "different", type = PartyType.OrganizationEntity),
                 signedFile = signedFile
             )
         )

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/RouteTest.kt
@@ -50,7 +50,7 @@ class RouteTest : FunSpec({
     }
 
     test("PUT /{id}.pdf returns 204 when authorized as org and handler succeeds") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns Unit.right()
 
         testApplication {
@@ -62,7 +62,7 @@ class RouteTest : FunSpec({
         }
     }
     test("PUT /{id}.pdf returns 422 with missing signature message when handler fails to validate signature") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns ConfirmError.ValidateSignaturesError(
             SignatureValidationError.MissingBankIdSignature
         ).left()
@@ -84,7 +84,7 @@ class RouteTest : FunSpec({
     }
 
     test("PUT /{id}.pdf returns 400 Invalid token when authorization fails with InvalidToken error") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns AuthError.InvalidToken.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.InvalidToken.left()
         coEvery { handler.invoke(any()) } returns Unit.right()
 
         testApplication {
@@ -104,7 +104,7 @@ class RouteTest : FunSpec({
     }
 
     test("PUT /{id}.pdf returns 400 'Invalid input' when id is invalid") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns Unit.right()
 
         testApplication {
@@ -123,7 +123,7 @@ class RouteTest : FunSpec({
         }
     }
     test("PUT /{id}.pdf returns 400 'Missing input' when document is empty") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns Unit.right()
 
         testApplication {

--- a/src/test/kotlin/no/elhub/auth/features/documents/create/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/create/HandlerTest.kt
@@ -110,6 +110,22 @@ class HandlerTest : FunSpec({
         coEvery { partyService.resolve(requestedToIdentifier) } returns requestedToParty.right()
     }
 
+    test("returns InvalidPartyTypeError when authorized party is not an OrganizationEntity") {
+        val businessHandler = mockk<DocumentBusinessHandler>(relaxed = true)
+        val signatureService = mockk<SignatureService>(relaxed = true)
+        val documentRepository = mockk<DocumentRepository>(relaxed = true)
+        val partyService = mockk<PartyService>(relaxed = true)
+        val fileGenerator = mockk<FileGenerator>(relaxed = true)
+
+        val handler = Handler(businessHandler, signatureService, documentRepository, partyService, fileGenerator)
+
+        val response = handler(model.copy(authorizedParty = AuthorizationParty(id = "person-1", type = PartyType.Person)))
+
+        response.shouldBeLeft(CreateError.InvalidPartyTypeError)
+        coVerify(exactly = 0) { partyService.resolve(any()) }
+        coVerify(exactly = 0) { businessHandler.validateAndReturnDocumentCommand(any()) }
+    }
+
     test("returns saved document when dependencies succeed") {
         val businessHandler = mockk<DocumentBusinessHandler>()
         val signatureService = mockk<SignatureService>()

--- a/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/create/RouteTest.kt
@@ -107,7 +107,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 201 when authorized as org and handler succeeds") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -118,7 +118,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns approprate error when authorization fails") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns AuthError.InvalidToken.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.InvalidToken.left()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -129,7 +129,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 400 Bad Request with 'Invalid national identity number' handler fails with InvalidNinError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.InvalidNinError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -148,7 +148,7 @@ class RouteTest : FunSpec({
         }
     }
     test("POST / returns 500 Internal Server Error when handler fails with FileGenerationError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.FileGenerationError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -159,7 +159,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 400 with detail about missing field when missing field in request body") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.FileGenerationError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -178,7 +178,7 @@ class RouteTest : FunSpec({
         }
     }
     test("POST / returns 400 with specific field reference when invalid field value in request body") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.FileGenerationError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }

--- a/src/test/kotlin/no/elhub/auth/features/documents/get/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/get/RouteTest.kt
@@ -68,7 +68,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}[.pdf] returns 200 when authorized as person and handler succeeds") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -88,7 +88,7 @@ class RouteTest : FunSpec({
         }
     }
     test("GET /{id}[.pdf] returns 200 when authorized as org and handler succeeds") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -109,7 +109,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}.pdf returns not accepted on unsupported accept header") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -120,7 +120,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}[.pdf] returns 400 when UUID is invalid") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -131,7 +131,7 @@ class RouteTest : FunSpec({
         }
     }
     test("GET /{id}[.pdf] returns 401 Not authorized when authorization fails") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.NotAuthorized.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.NotAuthorized.left()
         coEvery { handler.invoke(any()) } returns document.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -142,7 +142,7 @@ class RouteTest : FunSpec({
         }
     }
     test("GET /{id}[.pdf] returns 500 Internal server error when handler fails with IOError") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns QueryError.IOError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }

--- a/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/query/RouteTest.kt
@@ -90,7 +90,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET / returns 200 when authorized as person and handler succeeds") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(documents, documents.size.toLong(), Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -101,7 +101,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET / returns 200 when authorized as org and handler succeeds") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns Page(documents, documents.size.toLong(), Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -111,7 +111,7 @@ class RouteTest : FunSpec({
         }
     }
     test("GET / returns 403 'Forbidden' when authorization fails with AccessDenied error") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
         coEvery { handler.invoke(any()) } returns Page(documents, documents.size.toLong(), Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -120,7 +120,7 @@ class RouteTest : FunSpec({
         }
     }
     test("GET / returns 500 Internal server error when authorized as org and handler fails with IOError") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns QueryError.IOError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -131,7 +131,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET with page params passes correct Pagination to handler") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(
             emptyList<AuthorizationDocument>(),
             0L,
@@ -145,7 +145,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET with status param passes correct status to handler") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(
             emptyList<AuthorizationDocument>(),
             0L,
@@ -168,7 +168,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET with status param returns BadRequest when supplying invalid status") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(
             emptyList<AuthorizationDocument>(),
             0L,
@@ -184,7 +184,7 @@ class RouteTest : FunSpec({
     }
     test("GET response meta and links contain correct pagination and status fields") {
         val pagination = Pagination(page = 0, size = 10)
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationDocument>(), 4L, pagination).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -207,7 +207,7 @@ class RouteTest : FunSpec({
 
     test("GET links on a middle page contain prev and next") {
         val pagination = Pagination(page = 1, size = 5)
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationDocument>(), 15L, pagination).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }

--- a/src/test/kotlin/no/elhub/auth/features/grants/consume/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/consume/RouteTest.kt
@@ -43,7 +43,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} with invalid uuid returns 400") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
 
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -56,7 +56,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} returns 400 Invalid token when authorization fails with Invalid token error") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns AuthError.InvalidToken.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.InvalidToken.left()
 
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -69,7 +69,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} returns 403 Forbidden when auth fails with unauthorized") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
 
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -81,7 +81,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} returns Bad Request when body contains an blank id in request body") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson<JsonApiConsumeRequest>("/$validUuid", patchGrantBody(id = ""))
@@ -90,7 +90,7 @@ class RouteTest : FunSpec({
         }
     }
     test("PATCH /{id} returns Bad Request when body contains an invalid uuid in request body") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/$validUuid", patchGrantBody(id = "not-a-uuid"))
@@ -100,7 +100,7 @@ class RouteTest : FunSpec({
         }
     }
     test("PATCH /{id} returns Conflict when type is not AuthorizationGrant") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/$validUuid", patchGrantBody(id = validUuid, type = "WrongType"))
@@ -110,7 +110,7 @@ class RouteTest : FunSpec({
         }
     }
     test("PATCH /{id} returns Bad Request when status is missing in attributes") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
 
@@ -132,7 +132,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} returns bad request when id in path is correct, but not in the requestbody") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val invalidUuid = "invalid-uuid"
@@ -155,7 +155,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} returns OK and calls handler on valid request") {
-        coEvery { authProvider.authorizeElhubService(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         val party = no.elhub.auth.features.common.party.AuthorizationParty("test", no.elhub.auth.features.common.party.PartyType.Person)
         val expectedGrant = AuthorizationGrant(
             id = UUID.fromString(validUuid),

--- a/src/test/kotlin/no/elhub/auth/features/grants/get/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/get/RouteTest.kt
@@ -33,7 +33,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return 400 when having invalid token") {
-        coEvery { authProvider.authorizeAll(any()) } returns AuthError.InvalidToken.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.InvalidToken.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid")
@@ -43,7 +43,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} returns forbund when getting unauthorized from authprovider") {
-        coEvery { authProvider.authorizeAll(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid")
@@ -53,7 +53,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} with invalid UUID should give bad request response") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val malformedUuid = "not-a-uuid"
@@ -64,7 +64,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} with valid uuid and no errors should give 200 OK") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         val party = no.elhub.auth.features.common.party.AuthorizationParty("test", no.elhub.auth.features.common.party.PartyType.Person)
         val expectedGrant = AuthorizationGrant(
             id = UUID.fromString(validUuid),
@@ -94,7 +94,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} returns 500 when handler throws exception") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         coEvery { handler.invoke(any()) } throws RuntimeException("Handler failure")
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -105,7 +105,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} returns 401 when not authorized as any party") {
-        coEvery { authProvider.authorizeAll(any()) } returns AuthError.NotAuthorized.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.NotAuthorized.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid")

--- a/src/test/kotlin/no/elhub/auth/features/grants/getscopes/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/getscopes/RouteTest.kt
@@ -51,7 +51,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 401 when authorization fails with InvalidToken") {
-        coEvery { authProvider.authorizeAll(any()) } returns AuthError.InvalidToken.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.InvalidToken.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid/scopes")
@@ -61,7 +61,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 401 when authorization fails with NotAuthorized") {
-        coEvery { authProvider.authorizeAll(any()) } returns AuthError.NotAuthorized.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.NotAuthorized.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid/scopes")
@@ -71,7 +71,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 403 when authorization fails with AccessDenied") {
-        coEvery { authProvider.authorizeAll(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid/scopes")
@@ -81,7 +81,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 400 when id is not a valid UUID") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             validateMalformedInputResponse(client.get("/not-a-uuid/scopes"))
@@ -90,7 +90,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 404 when handler returns ResourceNotFoundError") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         coEvery { handler(any()) } returns QueryError.ResourceNotFoundError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -101,7 +101,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 500 when handler returns IOError") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         coEvery { handler(any()) } returns QueryError.IOError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -112,7 +112,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 200 and correct body when authorized as system and handler succeeds") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         coEvery { handler(any()) } returns expectedScopes.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -134,7 +134,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 200 and correct body when authorized as person and handler succeeds") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler(any()) } returns expectedScopes.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -148,7 +148,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 200 and correct body when authorized as org and handler succeeds") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler(any()) } returns expectedScopes.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -162,7 +162,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id}/scopes returns 200 with empty list when handler returns no scopes") {
-        coEvery { authProvider.authorizeAll(any()) } returns authorizedSystem.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedSystem.right()
         coEvery { handler(any()) } returns emptyList<AuthorizationScope>().right()
         testApplication {
             setupAppWith { route(handler, authProvider) }

--- a/src/test/kotlin/no/elhub/auth/features/requests/create/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/create/HandlerTest.kt
@@ -39,7 +39,7 @@ class HandlerTest : FunSpec({
     val requestedFromIdentifier = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "01010112345")
     val requestedToIdentifier = PartyIdentifier(PartyIdentifierType.NationalIdentityNumber, "02020212345")
 
-    val requestedByParty = AuthorizationParty(id = requestedByIdentifier.idValue, type = PartyType.Organization)
+    val requestedByParty = AuthorizationParty(id = requestedByIdentifier.idValue, type = PartyType.OrganizationEntity)
     val requestedFromParty = AuthorizationParty(id = "person-1", type = PartyType.Person)
     val requestedToParty = AuthorizationParty(id = "person-2", type = PartyType.Person)
 
@@ -101,6 +101,20 @@ class HandlerTest : FunSpec({
         coEvery { partyService.resolve(requestedByIdentifier) } returns requestedByParty.right()
         coEvery { partyService.resolve(requestedFromIdentifier) } returns requestedFromParty.right()
         coEvery { partyService.resolve(requestedToIdentifier) } returns requestedToParty.right()
+    }
+
+    test("returns InvalidPartyTypeError when authorized party is not an OrganizationEntity") {
+        val businessHandler = mockk<ProxyRequestBusinessHandler>(relaxed = true)
+        val partyService = mockk<PartyService>(relaxed = true)
+        val requestRepo = mockk<RequestRepository>(relaxed = true)
+
+        val handler = Handler(businessHandler, partyService, requestRepo)
+
+        val response = handler(model.copy(authorizedParty = AuthorizationParty(id = "person-1", type = PartyType.Person)))
+
+        response.shouldBeLeft(CreateError.InvalidPartyTypeError)
+        coVerify(exactly = 0) { partyService.resolve(any()) }
+        coVerify(exactly = 0) { businessHandler.validateAndReturnRequestCommand(any()) }
     }
 
     test("returns saved request when dependencies succeed") {
@@ -165,7 +179,7 @@ class HandlerTest : FunSpec({
         coEvery { partyService.resolve(requestedByIdentifier) } returns requestedByParty.right()
 
         val handler = Handler(businessHandler, partyService, requestRepo)
-        val otherAuthorizedParty = AuthorizationParty(id = "other", type = PartyType.Organization)
+        val otherAuthorizedParty = AuthorizationParty(id = "other", type = PartyType.OrganizationEntity)
 
         val response = handler(model.copy(authorizedParty = otherAuthorizedParty))
 

--- a/src/test/kotlin/no/elhub/auth/features/requests/create/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/create/RouteTest.kt
@@ -89,7 +89,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 201 when authorized as BalanceSupplier org and handler succeeds") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns authorizationRequest.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -126,7 +126,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 201 when redirectURI is omitted from API request") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns authorizationRequest.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -150,7 +150,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 401 when authorization fails with InvalidToken") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns AuthError.InvalidToken.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.InvalidToken.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.postJson("/", examplePostBody)
@@ -160,7 +160,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 409 Conflict when type in body is not AuthorizationRequest") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val wrongTypeBody = examplePostBody.copy(
@@ -173,7 +173,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 400 when handler fails with InvalidNinError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.InvalidNinError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -193,7 +193,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 403 when handler fails with AuthorizationError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.AuthorizationError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -213,7 +213,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 500 when handler fails with PersistenceError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.PersistenceError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -224,7 +224,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 500 when handler fails with MappingError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.MappingError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -235,7 +235,7 @@ class RouteTest : FunSpec({
     }
 
     test("POST / returns 500 when handler fails with RequestedPartyError") {
-        coEvery { authProvider.authorizeMaskinporten(any()) } returns authorizedOrg.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrg.right()
         coEvery { handler.invoke(any()) } returns CreateError.RequestedPartyError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }

--- a/src/test/kotlin/no/elhub/auth/features/requests/get/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/get/RouteTest.kt
@@ -51,7 +51,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return forbidden when access is denied") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid")
@@ -61,7 +61,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return unauthorized when not authorized") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.NotAuthorized.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.NotAuthorized.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/$validUuid")
@@ -71,7 +71,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return bad request when having an invalid request ID") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/not-a-uuid")
@@ -81,7 +81,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return not found when handler returns ResourceNotFoundError") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns QueryError.ResourceNotFoundError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -92,7 +92,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return forbidden when handler returns NotAuthorizedError") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns QueryError.NotAuthorizedError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -103,7 +103,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return 500 when handler throws exception") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } throws RuntimeException("Unexpected error")
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -114,7 +114,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return OK with correct body when authorized as Person") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         val authorizationRequest = AuthorizationRequest(
             id = UUID.fromString(validUuid),
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
@@ -156,7 +156,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET /{id} should return OK with correct body when authorized as OrganizationEntity") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedOrganization.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedOrganization.right()
         val authorizationRequest = AuthorizationRequest(
             id = UUID.fromString(validUuid),
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,

--- a/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/query/RouteTest.kt
@@ -51,7 +51,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return forbidden when access is denied") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/")
@@ -61,7 +61,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return unauthorized when not authorized") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns AuthError.NotAuthorized.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.NotAuthorized.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.get("/")
@@ -71,7 +71,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return forbidden when handler returns NotAuthorizedError") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns QueryError.NotAuthorizedError.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -82,7 +82,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return 500 when handler throws exception") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } throws RuntimeException("Unexpected error")
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -93,7 +93,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return OK with empty list when handler returns no requests") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 0L, Pagination()).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
@@ -106,7 +106,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return OK with correct body when handler returns") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         val authorizationRequest = AuthorizationRequest(
             id = UUID.randomUUID(),
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
@@ -149,7 +149,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET should return OK with multiple items when handler returns multiple requests") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         val request1 = AuthorizationRequest(
             id = UUID.randomUUID(),
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
@@ -193,7 +193,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET with page params passes correct Pagination to handler") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(
             emptyList<AuthorizationRequest>(),
             0L,
@@ -207,7 +207,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET with status param passes correct status to handler") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(
             emptyList<AuthorizationRequest>(),
             0L,
@@ -230,7 +230,7 @@ class RouteTest : FunSpec({
     }
 
     test("GET with status param returns BadRequest when supplying invalid status") {
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(
             emptyList<AuthorizationRequest>(),
             0L,
@@ -247,7 +247,7 @@ class RouteTest : FunSpec({
 
     test("GET response meta and links contain correct pagination fields") {
         val pagination = Pagination(page = 1, size = 5)
-        coEvery { authProvider.authorizeEndUserOrMaskinporten(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         coEvery { handler.invoke(any()) } returns Page(emptyList<AuthorizationRequest>(), 15L, pagination).right()
         testApplication {
             setupAppWith { route(handler, authProvider) }

--- a/src/test/kotlin/no/elhub/auth/features/requests/update/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/update/RouteTest.kt
@@ -56,7 +56,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} Should return unauthorized when endUser is AccessDenied") {
-        coEvery { authProvider.authorizeEndUser(any()) } returns AuthError.AccessDenied.left()
+        coEvery { authProvider.authorize(any()) } returns AuthError.AccessDenied.left()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/random-id", "")
@@ -66,7 +66,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} Should return bad request when having an invalid requestID") {
-        coEvery { authProvider.authorizeEndUser(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/random-id", "")
@@ -76,7 +76,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} should return bad request when input body is wrong") {
-        coEvery { authProvider.authorizeEndUser(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/${authorizedPerson.id}", "{\"test\": \"badInput\" }")
@@ -92,7 +92,7 @@ class RouteTest : FunSpec({
         coVerify(exactly = 0) { handler.invoke(any()) }
     }
     test("PATCH /{id} should return bad request when id in path doesnt match the request body") {
-        coEvery { authProvider.authorizeEndUser(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/${UUID.randomUUID()}", requestData)
@@ -110,7 +110,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} should return Conflict when request type is not AuthorizationRequest") {
-        coEvery { authProvider.authorizeEndUser(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         testApplication {
             setupAppWith { route(handler, authProvider) }
             val response = client.patchJson("/${authorizedPerson.id}", requestBody.copy(data = requestData.copy(type = "InvalidType")))
@@ -120,7 +120,7 @@ class RouteTest : FunSpec({
     }
 
     test("PATCH /{id} should return OK when handler returns") {
-        coEvery { authProvider.authorizeEndUser(any()) } returns authorizedPerson.right()
+        coEvery { authProvider.authorize(any()) } returns authorizedPerson.right()
         val authorizationRequest = AuthorizationRequest(
             type = AuthorizationRequest.Type.ChangeOfBalanceSupplierForPerson,
             status = AuthorizationRequest.Status.Accepted,


### PR DESCRIPTION
AuthProvider now only resolves who is calling. Endpoint-level party type
restrictions are business rules and have been moved into the feature
handlers where they belong
