### PR TITLE
fix: strip Bearer prefix from Authorization header before sending token to PDP

### DIFF
--- a/src/main/kotlin/no/elhub/auth/config/Authorization.kt
+++ b/src/main/kotlin/no/elhub/auth/config/Authorization.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.logging.LoggingFormat
+import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.plugins.callid.callId
@@ -53,6 +54,12 @@ fun Application.configureAuthorization() {
             }
 
             traceIdResolver = { call -> call.callId }
+
+            tokenResolver = { call ->
+                call.request.headers[HttpHeaders.Authorization]
+                    ?.takeIf { it.startsWith("Bearer ") }
+                    ?.removePrefix("Bearer ")
+            }
 
             enforce { response ->
                 // Resolve the AuthorizationParty from the PDP response and store it on call attributes

--- a/src/test/kotlin/no/elhub/auth/features/common/PdpTestContainerExtension.kt
+++ b/src/test/kotlin/no/elhub/auth/features/common/PdpTestContainerExtension.kt
@@ -44,7 +44,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {
@@ -84,7 +84,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {
@@ -128,7 +128,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {
@@ -162,7 +162,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer invalid-token\"" }
+                      { "contains": "\"token\":\"invalid-token\"" }
                     ]
                   },
                   "response": {
@@ -200,7 +200,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {
@@ -241,7 +241,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {
@@ -268,7 +268,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {
@@ -295,7 +295,7 @@ class PdpTestContainerExtension() : BeforeSpecListener, AfterSpecListener {
                     "method": "POST",
                     "url": "$AUTHINFO_POLICY_ROUTE",
                     "bodyPatterns": [
-                      { "contains": "\"token\":\"Bearer $token\"" }
+                      { "contains": "\"token\":\"$token\"" }
                     ]
                   },
                   "response": {


### PR DESCRIPTION
The code change is a bug fix — the token resolver was forwarding the raw Authorization header value (including Bearer ) to the PDP, but the PDP expects only the bare token.