### PR TITLE
fix(requests/update): Ensure inconsistent db state is not possible

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
@@ -75,7 +75,7 @@ fun toValidationApiErrorResponse(detail: String? = null): Pair<HttpStatusCode, J
     buildApiErrorResponse(
         status = HttpStatusCode.UnprocessableEntity,
         title = "Validation error",
-        detail = detail.orEmpty().ifEmpty({ "The requested resource could not be found" })
+        detail = detail.orEmpty().ifEmpty { "The requested resource could not be found" }
     )
 
 fun toNotFoundApiErrorResponse(detail: String? = null): Pair<HttpStatusCode, JsonApiErrorCollection> =

--- a/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
@@ -32,6 +32,7 @@ abstract class RepositoryError : Error
 sealed class RepositoryWriteError : RepositoryError() {
     data object ConflictError : RepositoryWriteError()
     data object NotFoundError : RepositoryWriteError()
+    data object ExpiredError : RepositoryWriteError()
     data object UnexpectedError : RepositoryWriteError()
 }
 

--- a/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/common/DocumentRepository.kt
@@ -356,7 +356,7 @@ class ExposedDocumentRepository(
                     when (writeError) {
                         is RepositoryWriteError.NotFoundError -> ConfirmWithGrantError.DocumentError.NotFound
                         is RepositoryWriteError.ConflictError -> ConfirmWithGrantError.DocumentError.Conflict
-                        is RepositoryWriteError.UnexpectedError -> ConfirmWithGrantError.DocumentError.Unexpected
+                        else -> ConfirmWithGrantError.DocumentError.Unexpected
                     }
                 }.bind()
 

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -274,7 +274,9 @@ class ExposedRequestRepository(
             val now = currentTimeUtc()
             val rowsUpdated = AuthorizationRequestTable.update(
                 where = {
-                    (AuthorizationRequestTable.id eq requestId) and (AuthorizationRequestTable.requestStatus eq DatabaseRequestStatus.Pending) and (AuthorizationRequestTable.validTo greater now)
+                    (AuthorizationRequestTable.id eq requestId) and
+                        (AuthorizationRequestTable.requestStatus eq DatabaseRequestStatus.Pending) and
+                        (AuthorizationRequestTable.validTo greater now)
                 }
             ) {
                 it[requestStatus] = DatabaseRequestStatus.Rejected

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -379,9 +379,9 @@ class ExposedRequestRepository(
                     .singleOrNull() ?: raise(RepositoryWriteError.NotFoundError)
 
             if (rowsUpdated == 0) {
-                val isExpired = request[AuthorizationRequestTable.validTo] <= currentTimeUtc()
-                if (isExpired) raise(RepositoryWriteError.ExpiredError)
-                raise(RepositoryWriteError.ConflictError)
+                val isNonPending = request[AuthorizationRequestTable.requestStatus] != DatabaseRequestStatus.Pending
+                if (isNonPending) raise(RepositoryWriteError.ConflictError)
+                raise(RepositoryWriteError.ExpiredError)
             }
 
             findInternal(request)

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -271,14 +271,17 @@ class ExposedRequestRepository(
             "rejectRequest",
             { RepositoryWriteError.UnexpectedError }
         ) {
+            val now = currentTimeUtc()
             val rowsUpdated = AuthorizationRequestTable.update(
-                where = { AuthorizationRequestTable.id eq requestId }
+                where = {
+                    (AuthorizationRequestTable.id eq requestId) and (AuthorizationRequestTable.requestStatus eq DatabaseRequestStatus.Pending) and (AuthorizationRequestTable.validTo greater now)
+                }
             ) {
                 it[requestStatus] = DatabaseRequestStatus.Rejected
                 it[updatedAt] = currentTimeUtc()
             }
 
-            updateAndFetch(requestId, rowsUpdated).bind()
+            fetchUpdated(requestId, rowsUpdated).bind()
         }
 
     override suspend fun findScopeIds(requestId: UUID): Either<RepositoryReadError, List<UUID>> =
@@ -310,18 +313,27 @@ class ExposedRequestRepository(
                 .mapLeft { AcceptWithGrantError.RequestError.Unexpected }
                 .bind()
 
+            val now = currentTimeUtc()
             val rowsUpdated =
                 AuthorizationRequestTable.update(
-                    where = { AuthorizationRequestTable.id eq requestId }
+                    where = {
+                        (AuthorizationRequestTable.id eq requestId) and
+                            (AuthorizationRequestTable.validTo greater now) and
+                            (AuthorizationRequestTable.requestStatus eq DatabaseRequestStatus.Pending)
+                    }
                 ) {
                     it[requestStatus] = DatabaseRequestStatus.Accepted
                     it[updatedAt] = currentTimeUtc()
                     it[this.approvedBy] = approvedByRecord.id
                 }
 
-            val acceptedRequest = updateAndFetch(requestId, rowsUpdated)
-                .mapLeft { AcceptWithGrantError.RequestError.Unexpected }
-                .bind()
+            val acceptedRequest = fetchUpdated(requestId, rowsUpdated)
+                .mapLeft { error ->
+                    when (error) {
+                        is RepositoryWriteError.ConflictError -> AcceptWithGrantError.RequestError.AlreadyProcessed
+                        else -> AcceptWithGrantError.RequestError.Unexpected
+                    }
+                }.bind()
 
             grantRepository.insert(grant)
                 .mapLeft { AcceptWithGrantError.GrantError }
@@ -352,13 +364,13 @@ class ExposedRequestRepository(
         }
     }
 
-    private suspend fun updateAndFetch(
+    private fun fetchUpdated(
         requestId: UUID,
         rowsUpdated: Int
     ): Either<RepositoryError, AuthorizationRequest> =
         either {
             if (rowsUpdated == 0) {
-                raise(RepositoryWriteError.UnexpectedError)
+                raise(RepositoryWriteError.ConflictError)
             }
 
             val request =
@@ -372,7 +384,7 @@ class ExposedRequestRepository(
                 .bind()
         }
 
-    private suspend fun findInternal(request: ResultRow): Either<RepositoryReadError, AuthorizationRequest> =
+    private fun findInternal(request: ResultRow): Either<RepositoryReadError, AuthorizationRequest> =
         either {
             val requestedByDbId = request[AuthorizationRequestTable.requestedBy]
             val requestedFromDbId = request[AuthorizationRequestTable.requestedFrom]

--- a/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/common/RequestRepository.kt
@@ -333,6 +333,7 @@ class ExposedRequestRepository(
                 .mapLeft { error ->
                     when (error) {
                         is RepositoryWriteError.ConflictError -> AcceptWithGrantError.RequestError.AlreadyProcessed
+                        is RepositoryWriteError.ExpiredError -> AcceptWithGrantError.RequestError.Expired
                         else -> AcceptWithGrantError.RequestError.Unexpected
                     }
                 }.bind()
@@ -371,15 +372,17 @@ class ExposedRequestRepository(
         rowsUpdated: Int
     ): Either<RepositoryError, AuthorizationRequest> =
         either {
-            if (rowsUpdated == 0) {
-                raise(RepositoryWriteError.ConflictError)
-            }
-
             val request =
                 AuthorizationRequestTable
                     .selectAll()
                     .where { AuthorizationRequestTable.id eq requestId }
-                    .singleOrNull() ?: raise(RepositoryReadError.NotFoundError)
+                    .singleOrNull() ?: raise(RepositoryWriteError.NotFoundError)
+
+            if (rowsUpdated == 0) {
+                val isExpired = request[AuthorizationRequestTable.validTo] <= currentTimeUtc()
+                if (isExpired) raise(RepositoryWriteError.ExpiredError)
+                raise(RepositoryWriteError.ConflictError)
+            }
 
             findInternal(request)
                 .mapLeft { RepositoryWriteError.UnexpectedError }

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
@@ -29,6 +29,12 @@ class Handler(
             UpdateError.AuthorizedPartyNotAllowedToUpdateAuthorizationRequest
         }
 
+        when (request.status) {
+            AuthorizationRequest.Status.Accepted, AuthorizationRequest.Status.Rejected -> raise(UpdateError.AlreadyProcessed)
+            AuthorizationRequest.Status.Expired -> raise(UpdateError.Expired)
+            AuthorizationRequest.Status.Pending -> Unit
+        }
+
         when (command.newStatus) {
             AuthorizationRequest.Status.Accepted -> handleAccepted(request, command).bind()
             AuthorizationRequest.Status.Rejected -> handleRejected(request).bind()

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
@@ -29,12 +29,6 @@ class Handler(
             UpdateError.AuthorizedPartyNotAllowedToUpdateAuthorizationRequest
         }
 
-        when (request.status) {
-            AuthorizationRequest.Status.Accepted, AuthorizationRequest.Status.Rejected -> raise(UpdateError.AlreadyProcessed)
-            AuthorizationRequest.Status.Expired -> raise(UpdateError.Expired)
-            AuthorizationRequest.Status.Pending -> Unit
-        }
-
         when (command.newStatus) {
             AuthorizationRequest.Status.Accepted -> handleAccepted(request, command).bind()
             AuthorizationRequest.Status.Rejected -> handleRejected(request).bind()
@@ -74,6 +68,7 @@ class Handler(
             when (error) {
                 is AcceptWithGrantError.GrantError -> UpdateError.GrantCreationError
                 is AcceptWithGrantError.RequestError.AlreadyProcessed -> UpdateError.AlreadyProcessed
+                is AcceptWithGrantError.RequestError.Expired -> UpdateError.Expired
                 is AcceptWithGrantError.RequestError -> UpdateError.PersistenceError
             }
         }.bind()
@@ -94,6 +89,7 @@ class Handler(
         ).mapLeft { error ->
             when (error) {
                 is RepositoryWriteError.ConflictError -> UpdateError.AlreadyProcessed
+                is RepositoryWriteError.ExpiredError -> UpdateError.Expired
                 else -> UpdateError.PersistenceError
             }
         }

--- a/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/requests/update/Handler.kt
@@ -3,6 +3,7 @@ package no.elhub.auth.features.requests.update
 import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
+import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.common.AuthorizationGrantProperty
@@ -26,12 +27,6 @@ class Handler(
 
         ensure(request.requestedTo == command.authorizedParty) {
             UpdateError.AuthorizedPartyNotAllowedToUpdateAuthorizationRequest
-        }
-
-        when (request.status) {
-            AuthorizationRequest.Status.Accepted, AuthorizationRequest.Status.Rejected -> raise(UpdateError.AlreadyProcessed)
-            AuthorizationRequest.Status.Expired -> raise(UpdateError.Expired)
-            AuthorizationRequest.Status.Pending -> Unit
         }
 
         when (command.newStatus) {
@@ -71,8 +66,9 @@ class Handler(
             grantProperties = properties,
         ).mapLeft { error ->
             when (error) {
+                is AcceptWithGrantError.GrantError -> UpdateError.GrantCreationError
+                is AcceptWithGrantError.RequestError.AlreadyProcessed -> UpdateError.AlreadyProcessed
                 is AcceptWithGrantError.RequestError -> UpdateError.PersistenceError
-                AcceptWithGrantError.GrantError -> UpdateError.GrantCreationError
             }
         }.bind()
 
@@ -89,5 +85,10 @@ class Handler(
     private suspend fun handleRejected(originalRequest: AuthorizationRequest): Either<UpdateError, AuthorizationRequest> =
         requestRepository.rejectRequest(
             requestId = originalRequest.id,
-        ).mapLeft { UpdateError.PersistenceError }
+        ).mapLeft { error ->
+            when (error) {
+                is RepositoryWriteError.ConflictError -> UpdateError.AlreadyProcessed
+                else -> UpdateError.PersistenceError
+            }
+        }
 }

--- a/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
@@ -465,6 +465,39 @@ class ExposedRequestRepositoryTest : FunSpec({
             acceptResult.shouldBeLeft()
             acceptResult.value shouldBe AcceptWithGrantError.RequestError.AlreadyProcessed
         }
+
+        test("updating expired request produces ExpiredError") {
+            val request = generateRequestWithoutProperties().copy(
+                validTo = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1)
+            )
+            val savedRequest = requestRepo
+                .insert(request, scopes)
+                .getOrElse { fail("insert failed") }
+
+            val rejectResult = requestRepo.rejectRequest(savedRequest.id)
+            rejectResult.shouldBeLeft()
+            rejectResult.value shouldBe RepositoryWriteError.ExpiredError
+
+            val party = AuthorizationParty(type = PartyType.Person, id = "🐟")
+            val grant = AuthorizationGrant.create(
+                grantedFor = party,
+                grantedBy = party,
+                grantedTo = party,
+                sourceType = AuthorizationGrant.SourceType.Request,
+                sourceId = savedRequest.id,
+                scopeIds = listOf(),
+                validFrom = currentTimeUtc(),
+                validTo = currentTimeUtc().plusDays(365),
+            )
+            val acceptResult = requestRepo.acceptWithGrant(
+                requestId = savedRequest.id,
+                approvedBy = party,
+                grant = grant,
+                grantProperties = listOf(),
+            )
+            acceptResult.shouldBeLeft()
+            acceptResult.value shouldBe AcceptWithGrantError.RequestError.Expired
+        }
     }
 
     context("acceptWithGrant") {

--- a/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/common/ExposedRequestRepositoryTest.kt
@@ -1,6 +1,7 @@
 package no.elhub.auth.features.requests.common
 
 import arrow.core.getOrElse
+import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.fail
 import io.kotest.core.spec.style.FunSpec
@@ -16,6 +17,7 @@ import no.elhub.auth.features.common.CreateScopeData
 import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.PostgresTestContainer
 import no.elhub.auth.features.common.PostgresTestContainerExtension
+import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.RunPostgresScriptExtension
 import no.elhub.auth.features.common.currentTimeUtc
 import no.elhub.auth.features.common.party.AuthorizationParty
@@ -427,6 +429,42 @@ class ExposedRequestRepositoryTest : FunSpec({
 
         rejectedRequest.properties.size shouldBe 2
         rejectedRequest.status shouldBe AuthorizationRequest.Status.Rejected
+    }
+
+    context("state validation") {
+        test("updating already-rejected request produces ConflictError") {
+            val request = generateRequestWithoutProperties()
+            val savedRequest = requestRepo
+                .insert(request, scopes)
+                .getOrElse { fail("insert failed") }
+
+            val firstRejectResult = requestRepo.rejectRequest(request.id)
+            firstRejectResult.shouldBeRight()
+
+            val secondRejectResult = requestRepo.rejectRequest(request.id)
+            secondRejectResult.shouldBeLeft()
+            secondRejectResult.value shouldBe RepositoryWriteError.ConflictError
+
+            val party = AuthorizationParty(type = PartyType.Person, id = "🐟")
+            val grant = AuthorizationGrant.create(
+                grantedFor = party,
+                grantedBy = party,
+                grantedTo = party,
+                sourceType = AuthorizationGrant.SourceType.Request,
+                sourceId = savedRequest.id,
+                scopeIds = listOf(),
+                validFrom = currentTimeUtc(),
+                validTo = currentTimeUtc().plusDays(365),
+            )
+            val acceptResult = requestRepo.acceptWithGrant(
+                requestId = savedRequest.id,
+                approvedBy = party,
+                grant = grant,
+                grantProperties = listOf(),
+            )
+            acceptResult.shouldBeLeft()
+            acceptResult.value shouldBe AcceptWithGrantError.RequestError.AlreadyProcessed
+        }
     }
 
     context("acceptWithGrant") {

--- a/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
@@ -18,6 +18,7 @@ import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
 import no.elhub.auth.features.common.todayOslo
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import no.elhub.auth.features.requests.AuthorizationRequest
+import no.elhub.auth.features.requests.common.AcceptWithGrantError
 import no.elhub.auth.features.requests.common.RequestBusinessHandler
 import no.elhub.auth.features.requests.common.RequestRepository
 import java.time.OffsetDateTime
@@ -45,7 +46,7 @@ class HandlerTest : FunSpec({
             id = requestId,
         )
 
-    test("returns IllegalStateError when request is not pending") {
+    test("returns AlreadyProcessedError when trying to accept and repo returns AlreadyProcessed") {
         val requestId = UUID.randomUUID()
         val request = createRequest(requestId).copy(
             id = requestId,
@@ -55,6 +56,14 @@ class HandlerTest : FunSpec({
         val businessHandler = mockk<RequestBusinessHandler>()
 
         coEvery { requestRepository.find(requestId) } returns request.right()
+        coEvery {
+            requestRepository.acceptWithGrant(requestId, any(), any(), any())
+        } returns AcceptWithGrantError.RequestError.AlreadyProcessed.left()
+        coEvery { requestRepository.findScopeIds(requestId) } returns listOf<UUID>().right()
+        coEvery { businessHandler.getCreateGrantProperties(any()) } returns CreateGrantProperties(
+            todayOslo(),
+            todayOslo()
+        )
 
         val handler = Handler(
             businessHandler = businessHandler,
@@ -71,7 +80,7 @@ class HandlerTest : FunSpec({
 
         result.shouldBeLeft(UpdateError.AlreadyProcessed)
         coVerify(exactly = 1) { requestRepository.find(requestId) }
-        coVerify(exactly = 0) { requestRepository.acceptWithGrant(any(), any(), any(), any()) }
+        coVerify(exactly = 1) { requestRepository.acceptWithGrant(any(), any(), any(), any()) }
         coVerify(exactly = 0) { requestRepository.rejectRequest(any()) }
     }
 

--- a/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
@@ -50,7 +50,7 @@ class HandlerTest : FunSpec({
         val requestId = UUID.randomUUID()
         val request = createRequest(requestId).copy(
             id = requestId,
-            status = AuthorizationRequest.Status.Accepted
+            status = AuthorizationRequest.Status.Pending
         )
         val requestRepository = mockk<RequestRepository>()
         val businessHandler = mockk<RequestBusinessHandler>()

--- a/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/requests/update/HandlerTest.kt
@@ -11,6 +11,8 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
+import no.elhub.auth.features.common.RepositoryWriteError.ConflictError
+import no.elhub.auth.features.common.RepositoryWriteError.ExpiredError
 import no.elhub.auth.features.common.RepositoryWriteError.UnexpectedError
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyType
@@ -147,5 +149,87 @@ class HandlerTest : FunSpec({
         )
 
         result.shouldBeLeft(UpdateError.PersistenceError)
+    }
+
+    test("returns AlreadyProcessed when rejecting and repo returns ConflictError") {
+        val requestId = UUID.randomUUID()
+        val request = createRequest(requestId)
+        val requestRepository = mockk<RequestRepository>()
+        val businessHandler = mockk<RequestBusinessHandler>()
+
+        coEvery { requestRepository.find(requestId) } returns request.right()
+        coEvery { requestRepository.rejectRequest(requestId) } returns ConflictError.left()
+
+        val handler = Handler(
+            businessHandler = businessHandler,
+            requestRepository = requestRepository,
+        )
+
+        val result = handler(
+            UpdateCommand(
+                requestId = requestId,
+                newStatus = AuthorizationRequest.Status.Rejected,
+                authorizedParty = requestedTo
+            )
+        )
+
+        result.shouldBeLeft(UpdateError.AlreadyProcessed)
+    }
+
+    test("returns Expired when rejecting and repo returns ExpiredError") {
+        val requestId = UUID.randomUUID()
+        val request = createRequest(requestId)
+        val requestRepository = mockk<RequestRepository>()
+        val businessHandler = mockk<RequestBusinessHandler>()
+
+        coEvery { requestRepository.find(requestId) } returns request.right()
+        coEvery { requestRepository.rejectRequest(requestId) } returns ExpiredError.left()
+
+        val handler = Handler(
+            businessHandler = businessHandler,
+            requestRepository = requestRepository,
+        )
+
+        val result = handler(
+            UpdateCommand(
+                requestId = requestId,
+                newStatus = AuthorizationRequest.Status.Rejected,
+                authorizedParty = requestedTo
+            )
+        )
+
+        result.shouldBeLeft(UpdateError.Expired)
+    }
+
+    test("returns Expired when accepting and repo returns Expired") {
+        val requestId = UUID.randomUUID()
+        val request = createRequest(requestId)
+        val requestRepository = mockk<RequestRepository>()
+        val businessHandler = mockk<RequestBusinessHandler>()
+
+        coEvery { requestRepository.find(requestId) } returns request.right()
+        coEvery {
+            requestRepository.acceptWithGrant(requestId, any(), any(), any())
+        } returns AcceptWithGrantError.RequestError.Expired.left()
+        coEvery { requestRepository.findScopeIds(requestId) } returns listOf<UUID>().right()
+        coEvery { businessHandler.getCreateGrantProperties(any()) } returns CreateGrantProperties(
+            todayOslo(),
+            todayOslo()
+        )
+
+        val handler = Handler(
+            businessHandler = businessHandler,
+            requestRepository = requestRepository,
+        )
+
+        val result = handler(
+            UpdateCommand(
+                requestId = requestId,
+                newStatus = AuthorizationRequest.Status.Accepted,
+                authorizedParty = requestedTo
+            )
+        )
+
+        result.shouldBeLeft(UpdateError.Expired)
     }
 })


### PR DESCRIPTION
Part of https://elhub.atlassian.net/browse/TDX-1576

Moves state validation of the request from handler to repo, ensuring a request cannot be accepted and then rejected with terrible concurrency luck.

Some other small things:
- Remove unnecessary `suspend` for some blocking functions.
- Rename `updateAndFetch` to `fetchUpdated` because that's what it's doing :D