### PR TITLE
fix(grants/consume): Ensure consume atomicity

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/common/GrantRepository.kt
@@ -26,6 +26,7 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.java.UUIDTable
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.java.javaUUID
 import org.jetbrains.exposed.v1.core.or
@@ -39,9 +40,17 @@ import java.util.UUID
 
 interface GrantRepository {
     suspend fun find(grantId: UUID): Either<RepositoryReadError, AuthorizationGrant>
-    suspend fun findBySourceIds(sourceType: SourceType, sourceIds: List<UUID>): Either<RepositoryReadError, Map<UUID, AuthorizationGrant>>
+    suspend fun findBySourceIds(
+        sourceType: SourceType,
+        sourceIds: List<UUID>
+    ): Either<RepositoryReadError, Map<UUID, AuthorizationGrant>>
+
     suspend fun findScopes(grantId: UUID): Either<RepositoryReadError, List<AuthorizationScope>>
-    suspend fun findAll(party: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationGrant>>
+    suspend fun findAll(
+        party: AuthorizationParty,
+        pagination: Pagination
+    ): Either<RepositoryReadError, Page<AuthorizationGrant>>
+
     suspend fun insert(grant: AuthorizationGrant): Either<RepositoryWriteError, AuthorizationGrant>
     suspend fun update(grantId: UUID, newStatus: Status): Either<RepositoryError, AuthorizationGrant>
 }
@@ -54,7 +63,10 @@ class ExposedGrantRepository(
 
     private val logger = LoggerFactory.getLogger(ExposedGrantRepository::class.java)
 
-    override suspend fun findAll(party: AuthorizationParty, pagination: Pagination): Either<RepositoryReadError, Page<AuthorizationGrant>> =
+    override suspend fun findAll(
+        party: AuthorizationParty,
+        pagination: Pagination
+    ): Either<RepositoryReadError, Page<AuthorizationGrant>> =
         transactionContext<RepositoryReadError, Page<AuthorizationGrant>>(
             "db_operations",
             "GrantRepository",
@@ -66,7 +78,8 @@ class ExposedGrantRepository(
                 .bind()
                 .id
 
-            val whereClause = { (AuthorizationGrantTable.grantedTo eq partyId) or (AuthorizationGrantTable.grantedFor eq partyId) }
+            val whereClause =
+                { (AuthorizationGrantTable.grantedTo eq partyId) or (AuthorizationGrantTable.grantedFor eq partyId) }
 
             val totalItems = AuthorizationGrantTable
                 .selectAll()
@@ -141,7 +154,12 @@ class ExposedGrantRepository(
             "find",
             { RepositoryReadError.UnexpectedError }
         ) {
-            findInternalGrant(grantId).bind()
+            val row = AuthorizationGrantTable
+                .selectAll()
+                .where { AuthorizationGrantTable.id eq grantId }
+                .singleOrNull() ?: raise(RepositoryReadError.NotFoundError)
+
+            findInternal(row).bind()
         }
 
     override suspend fun findBySourceIds(
@@ -318,27 +336,46 @@ class ExposedGrantRepository(
             "update",
             { RepositoryWriteError.UnexpectedError }
         ) {
+            val now = currentTimeUtc()
             val rowsUpdated =
                 AuthorizationGrantTable.update(
-                    where = { AuthorizationGrantTable.id eq grantId }
+                    where = {
+                        (AuthorizationGrantTable.id eq grantId) and
+                            (AuthorizationGrantTable.grantStatus eq Status.Active) and
+                            (AuthorizationGrantTable.validTo greater now)
+                    }
                 ) {
                     it[grantStatus] = newStatus
                     it[updatedAt] = currentTimeUtc()
                 }
 
-            if (rowsUpdated == 0) raise(RepositoryWriteError.UnexpectedError)
-
-            findInternalGrant(grantId)
-                .mapLeft { RepositoryReadError.UnexpectedError }
-                .bind()
+            fetchUpdated(grantId, rowsUpdated).bind()
         }
 
-    private suspend fun findInternalGrant(grantId: UUID): Either<RepositoryReadError, AuthorizationGrant> =
+    private suspend fun fetchUpdated(
+        grantId: UUID,
+        rowsUpdated: Int
+    ): Either<RepositoryError, AuthorizationGrant> =
         either {
             val grant = AuthorizationGrantTable
                 .selectAll()
                 .where { AuthorizationGrantTable.id eq grantId }
-                .singleOrNull() ?: raise(RepositoryReadError.NotFoundError)
+                .singleOrNull() ?: raise(RepositoryWriteError.NotFoundError)
+
+            if (rowsUpdated == 0) {
+                val isProcessed = grant[AuthorizationGrantTable.grantStatus] != Status.Active
+                if (isProcessed) raise(RepositoryWriteError.ConflictError)
+                raise(RepositoryWriteError.ExpiredError)
+            }
+
+            findInternal(grant)
+                .mapLeft { RepositoryWriteError.UnexpectedError }
+                .bind()
+        }
+
+    private suspend fun findInternal(grant: ResultRow): Either<RepositoryReadError, AuthorizationGrant> =
+        either {
+            val grantId = grant[AuthorizationGrantTable.id].value
 
             val scopes = findScopeIds(grantId).bind()
 
@@ -373,7 +410,7 @@ class ExposedGrantRepository(
                     }
                     .bind()
 
-            val properties = grantPropertiesRepository.findBy(grantId = grant[AuthorizationGrantTable.id].value)
+            val properties = grantPropertiesRepository.findBy(grantId = grantId)
 
             grant.toAuthorizationGrant(
                 grantedBy = grantedByParty,

--- a/src/main/kotlin/no/elhub/auth/features/grants/consume/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/grants/consume/Handler.kt
@@ -3,7 +3,7 @@ package no.elhub.auth.features.grants.consume
 import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
-import no.elhub.auth.features.common.currentTimeUtc
+import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.AuthorizationGrant.Status
@@ -20,20 +20,14 @@ class Handler(
             ConsumeError.IllegalTransitionError
         }
 
-        val originalGrant = repo.find(command.grantId)
-            .mapLeft { ConsumeError.GrantNotFound }
-            .bind()
-
-        ensure(originalGrant.validTo >= currentTimeUtc()) {
-            ConsumeError.ExpiredError
-        }
-
-        ensure(originalGrant.grantStatus == Status.Active) {
-            ConsumeError.IllegalStateError
-        }
-
         repo.update(command.grantId, command.newStatus)
-            .mapLeft { ConsumeError.PersistenceError }
+            .mapLeft { error ->
+                when (error) {
+                    is RepositoryWriteError.ConflictError -> ConsumeError.IllegalStateError
+                    is RepositoryWriteError.ExpiredError -> ConsumeError.ExpiredError
+                    else -> ConsumeError.PersistenceError
+                }
+            }
             .bind()
     }
 }

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -275,7 +275,7 @@ class ExposedGrantRepositoryTest : FunSpec({
         updateResult2.value shouldBe RepositoryWriteError.ConflictError
     }
 
-    xtest("update should return ExpiredError for expired grant") {
+    test("update should return ExpiredError for expired grant") {
         insertTestData()
         val id = UUID.fromString("2a28a9dd-d3b3-4dec-a420-3f7d0d0105b7")
         val updateResult = grantRepo.update(

--- a/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/common/ExposedGrantRepositoryTest.kt
@@ -16,6 +16,7 @@ import no.elhub.auth.features.common.Pagination
 import no.elhub.auth.features.common.PostgresTestContainer
 import no.elhub.auth.features.common.PostgresTestContainerExtension
 import no.elhub.auth.features.common.RepositoryReadError
+import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.AuthorizationPartyTable
 import no.elhub.auth.features.common.party.ExposedPartyRepository
@@ -252,6 +253,37 @@ class ExposedGrantRepositoryTest : FunSpec({
         }
 
         grant.grantStatus shouldBe AuthorizationGrant.Status.Exhausted
+    }
+
+    test("update should return ConflictError for already-exhausted grant") {
+        insertTestData()
+        val id = UUID.fromString("456e4567-e89b-12d3-a456-426614174000")
+        val updateResult1 = grantRepo.update(
+            grantId = id,
+            newStatus = AuthorizationGrant.Status.Exhausted
+        ).getOrElse {
+            fail("Failed to update grant")
+        }
+        updateResult1.grantStatus shouldBe AuthorizationGrant.Status.Exhausted
+
+        val updateResult2 = grantRepo.update(
+            grantId = id,
+            newStatus = AuthorizationGrant.Status.Exhausted
+        )
+
+        updateResult2.shouldBeLeft()
+        updateResult2.value shouldBe RepositoryWriteError.ConflictError
+    }
+
+    xtest("update should return ExpiredError for expired grant") {
+        insertTestData()
+        val id = UUID.fromString("2a28a9dd-d3b3-4dec-a420-3f7d0d0105b7")
+        val updateResult = grantRepo.update(
+            grantId = id,
+            newStatus = AuthorizationGrant.Status.Exhausted
+        )
+        updateResult.shouldBeLeft()
+        updateResult.value shouldBe RepositoryWriteError.ExpiredError
     }
 })
 

--- a/src/test/kotlin/no/elhub/auth/features/grants/consume/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/grants/consume/HandlerTest.kt
@@ -9,7 +9,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.coEvery
 import io.mockk.mockk
 import no.elhub.auth.features.common.RepositoryError
-import no.elhub.auth.features.common.RepositoryReadError
 import no.elhub.auth.features.common.RepositoryWriteError
 import no.elhub.auth.features.common.currentTimeUtc
 import no.elhub.auth.features.common.party.AuthorizationParty
@@ -77,12 +76,10 @@ class HandlerTest : FunSpec({
     )
 
     fun repoReturning(
-        updateResult: Either<RepositoryError, AuthorizationGrant>,
-        findResult: Either<RepositoryReadError, AuthorizationGrant> = activeGrant.right(),
+        updateResult: Either<RepositoryError, AuthorizationGrant>
     ): GrantRepository =
         mockk<GrantRepository> {
             coEvery { update(grantId, newStatus) } returns updateResult
-            coEvery { find(grantId) } returns findResult
         }
 
     test("maps repository error to PersistenceError") {
@@ -115,17 +112,12 @@ class HandlerTest : FunSpec({
         response.shouldBeRight(updatedGrant)
     }
 
-    test("returns ExpiredError when grant is expired") {
+    test("returns ExpiredError when repo returns ExpiredError") {
         val expiredGrant = activeGrant.copy(
             validTo = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(1)
         )
 
-        val handler = Handler(
-            repoReturning(
-                findResult = expiredGrant.right(),
-                updateResult = updatedGrant.right()
-            )
-        )
+        val handler = Handler(repoReturning(updateResult = RepositoryWriteError.ExpiredError.left()))
         val response = handler(
             ConsumeCommand(
                 grantId = grantId,
@@ -137,15 +129,10 @@ class HandlerTest : FunSpec({
         response.shouldBeLeft(ConsumeError.ExpiredError)
     }
 
-    test("returns IllegalStateError when grant is not active") {
+    test("returns IllegalStateError when repo returns ConflictError") {
         val exhaustedGrant = activeGrant.copy(grantStatus = Status.Exhausted)
 
-        val handler = Handler(
-            repoReturning(
-                findResult = exhaustedGrant.right(),
-                updateResult = exhaustedGrant.right()
-            )
-        )
+        val handler = Handler(repoReturning(updateResult = RepositoryWriteError.ConflictError.left()))
 
         val response = handler(
             ConsumeCommand(
@@ -159,12 +146,7 @@ class HandlerTest : FunSpec({
     }
 
     test("returns IllegalTransitionError when attempting to update grant to 'Active'") {
-        val handler = Handler(
-            repoReturning(
-                findResult = activeGrant.right(),
-                updateResult = updatedGrant.right()
-            )
-        )
+        val handler = Handler(repoReturning(updateResult = updatedGrant.right()))
         val response = handler(
             ConsumeCommand(
                 grantId = grantId,

--- a/src/test/resources/db/insert-authorization-grants.sql
+++ b/src/test/resources/db/insert-authorization-grants.sql
@@ -1,91 +1,186 @@
 -- Test data for authorization grants
-INSERT INTO auth.authorization_grant (id, granted_for, granted_by, granted_to, granted_at, status, valid_from, valid_to,
-                                      source_type, source_id, created_at, updated_at)
-VALUES ('123e4567-e89b-12d3-a456-426614174000',
-        '11111111-1111-1111-1111-111111111111',
-        '11111111-1111-1111-1111-111111111111',
-        '55555555-5555-5555-5555-555555555555',
-        '2025-04-04 02:00:00.000000+00',
-        'Active',
-        '2025-04-04 02:00:00.000000+00',
-        NOW() + INTERVAL '10 days',
-        'Request',
-        '4f71d596-99e4-415e-946d-7252c1a40c5b',
-        '2025-04-04 02:00:00.000000+00',
-        '2025-04-04 02:00:00.000000+00');
+INSERT INTO
+  auth.authorization_grant (
+    id,
+    granted_for,
+    granted_by,
+    granted_to,
+    granted_at,
+    status,
+    valid_from,
+    valid_to,
+    source_type,
+    source_id,
+    created_at,
+    updated_at
+  )
+VALUES
+  (
+    '123e4567-e89b-12d3-a456-426614174000',
+    '11111111-1111-1111-1111-111111111111',
+    '11111111-1111-1111-1111-111111111111',
+    '55555555-5555-5555-5555-555555555555',
+    '2025-04-04 02:00:00.000000+00',
+    'Active',
+    '2025-04-04 02:00:00.000000+00',
+    NOW () + INTERVAL '10 days',
+    'Request',
+    '4f71d596-99e4-415e-946d-7252c1a40c5b',
+    '2025-04-04 02:00:00.000000+00',
+    '2025-04-04 02:00:00.000000+00'
+  );
 
-INSERT INTO auth.authorization_grant (id, granted_for, granted_by, granted_to, granted_at, status, valid_from, valid_to,
-                                      source_type, source_id, created_at, updated_at)
-VALUES ('b7f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a',
-        '33333333-3333-3333-3333-333333333333',
-        '33333333-3333-3333-3333-333333333333',
-        '22222222-2222-2222-2222-222222222222',
-        '2023-04-04 02:00:00.000000+00',
-        'Revoked',
-        '2023-04-04 02:00:00.000000+00',
-        '2024-04-04 02:00:00.000000+00',
-        'Request',
-        '4f71d596-99e4-415e-946d-7252c1a40c51',
-        '2023-04-04 02:00:00.000000+00',
-        '2023-04-04 02:00:00.000000+00');
+INSERT INTO
+  auth.authorization_grant (
+    id,
+    granted_for,
+    granted_by,
+    granted_to,
+    granted_at,
+    status,
+    valid_from,
+    valid_to,
+    source_type,
+    source_id,
+    created_at,
+    updated_at
+  )
+VALUES
+  (
+    'b7f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a',
+    '33333333-3333-3333-3333-333333333333',
+    '33333333-3333-3333-3333-333333333333',
+    '22222222-2222-2222-2222-222222222222',
+    '2023-04-04 02:00:00.000000+00',
+    'Revoked',
+    '2023-04-04 02:00:00.000000+00',
+    '2024-04-04 02:00:00.000000+00',
+    'Request',
+    '4f71d596-99e4-415e-946d-7252c1a40c51',
+    '2023-04-04 02:00:00.000000+00',
+    '2023-04-04 02:00:00.000000+00'
+  );
 
-INSERT INTO auth.authorization_grant (id, granted_for, granted_by, granted_to, granted_at, status, valid_from, valid_to,
-                                      source_type, source_id, created_at, updated_at)
-VALUES ('a8f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a',
-        '44444444-4444-4444-4444-444444444444',
-        '33333333-3333-3333-3333-333333333333',
-        '55555555-5555-5555-5555-555555555555',
-        '2025-01-04 02:00:00.000000+00',
-        'Revoked',
-        '2025-02-03 16:07:00.000000+00',
-        '2025-05-16 02:00:00.000000+00',
-        'Request',
-        '4f71d596-99e4-415e-946d-7252c1a40c52',
-        '2025-01-04 02:00:00.000000+00',
-        '2025-01-04 02:00:00.000000+00');
+INSERT INTO
+  auth.authorization_grant (
+    id,
+    granted_for,
+    granted_by,
+    granted_to,
+    granted_at,
+    status,
+    valid_from,
+    valid_to,
+    source_type,
+    source_id,
+    created_at,
+    updated_at
+  )
+VALUES
+  (
+    'a8f9c2e4-5a3d-4e2b-9c1a-8f6e2d3c4b5a',
+    '44444444-4444-4444-4444-444444444444',
+    '33333333-3333-3333-3333-333333333333',
+    '55555555-5555-5555-5555-555555555555',
+    '2025-01-04 02:00:00.000000+00',
+    'Revoked',
+    '2025-02-03 16:07:00.000000+00',
+    '2025-05-16 02:00:00.000000+00',
+    'Request',
+    '4f71d596-99e4-415e-946d-7252c1a40c52',
+    '2025-01-04 02:00:00.000000+00',
+    '2025-01-04 02:00:00.000000+00'
+  );
 
+INSERT INTO
+  auth.authorization_grant (
+    id,
+    granted_for,
+    granted_by,
+    granted_to,
+    granted_at,
+    status,
+    valid_from,
+    valid_to,
+    source_type,
+    source_id,
+    created_at,
+    updated_at
+  )
+VALUES
+  (
+    'd75522ba-0e62-449b-b1de-70b16f12ecaf',
+    '33333333-3333-3333-3333-333333333333',
+    '33333333-3333-3333-3333-333333333333',
+    '55555555-5555-5555-5555-555555555555',
+    '2023-04-04 02:00:00.000000+00',
+    'Revoked',
+    '2023-04-04 02:00:00.000000+00',
+    '2024-04-04 02:00:00.000000+00',
+    'Request',
+    '8150d80b-3a48-401e-a6d5-025bd3aa1254',
+    '2023-04-04 02:00:00.000000+00',
+    '2023-04-04 02:00:00.000000+00'
+  );
 
-INSERT INTO auth.authorization_grant (id, granted_for, granted_by, granted_to, granted_at, status, valid_from, valid_to,
-                                      source_type, source_id, created_at, updated_at)
-VALUES ('d75522ba-0e62-449b-b1de-70b16f12ecaf',
-        '33333333-3333-3333-3333-333333333333',
-        '33333333-3333-3333-3333-333333333333',
-        '55555555-5555-5555-5555-555555555555',
-        '2023-04-04 02:00:00.000000+00',
-        'Revoked',
-        '2023-04-04 02:00:00.000000+00',
-        '2024-04-04 02:00:00.000000+00',
-        'Request',
-        '8150d80b-3a48-401e-a6d5-025bd3aa1254',
-        '2023-04-04 02:00:00.000000+00',
-        '2023-04-04 02:00:00.000000+00');
+INSERT INTO
+  auth.authorization_grant (
+    id,
+    granted_for,
+    granted_by,
+    granted_to,
+    granted_at,
+    status,
+    valid_from,
+    valid_to,
+    source_type,
+    source_id,
+    created_at,
+    updated_at
+  )
+VALUES
+  (
+    '456e4567-e89b-12d3-a456-426614174000',
+    '55555555-5555-5555-5555-555555555555',
+    '55555555-5555-5555-5555-555555555555',
+    '22222222-2222-2222-2222-222222222222',
+    '2025-04-04 02:00:00.000000+00',
+    'Active',
+    '2025-04-04 02:00:00.000000+00',
+    '2030-04-04 02:00:00.000000+00',
+    'Request',
+    '4f71d596-99e4-415e-946d-7252c1a40c50',
+    '2025-04-04 02:00:00.000000+00',
+    '2025-04-04 02:00:00.000000+00'
+  );
 
-INSERT INTO auth.authorization_grant (id, granted_for, granted_by, granted_to, granted_at, status, valid_from, valid_to,
-                                      source_type, source_id, created_at, updated_at)
-VALUES ('456e4567-e89b-12d3-a456-426614174000',
-        '55555555-5555-5555-5555-555555555555',
-        '55555555-5555-5555-5555-555555555555',
-        '22222222-2222-2222-2222-222222222222',
-        '2025-04-04 02:00:00.000000+00',
-        'Active',
-        '2025-04-04 02:00:00.000000+00',
-        '2026-04-04 02:00:00.000000+00',
-        'Request',
-        '4f71d596-99e4-415e-946d-7252c1a40c50',
-        '2025-04-04 02:00:00.000000+00',
-        '2025-04-04 02:00:00.000000+00');
-
-INSERT INTO auth.authorization_grant (id, granted_for, granted_by, granted_to, granted_at, status, valid_from, valid_to,
-                                      source_type, source_id, created_at, updated_at)
-VALUES ('2a28a9dd-d3b3-4dec-a420-3f7d0d0105b7',
-        '55555555-5555-5555-5555-555555555555',
-        '55555555-5555-5555-5555-555555555555',
-        '22222222-2222-2222-2222-222222222222',
-        '2025-04-04 02:00:00.000000+00',
-        'Active',
-        '2025-04-04 02:00:00.000000+00',
-        '2026-01-10 02:00:00.000000+00',
-        'Request',
-        '71214c5a-a351-45c6-a231-79fa865acbb4',
-        '2025-04-04 02:00:00.000000+00',
-        '2025-04-04 02:00:00.000000+00');
+INSERT INTO
+  auth.authorization_grant (
+    id,
+    granted_for,
+    granted_by,
+    granted_to,
+    granted_at,
+    status,
+    valid_from,
+    valid_to,
+    source_type,
+    source_id,
+    created_at,
+    updated_at
+  )
+VALUES
+  (
+    '2a28a9dd-d3b3-4dec-a420-3f7d0d0105b7',
+    '55555555-5555-5555-5555-555555555555',
+    '55555555-5555-5555-5555-555555555555',
+    '22222222-2222-2222-2222-222222222222',
+    '2025-04-04 02:00:00.000000+00',
+    'Active',
+    '2025-04-04 02:00:00.000000+00',
+    '2026-01-10 02:00:00.000000+00',
+    'Request',
+    '71214c5a-a351-45c6-a231-79fa865acbb4',
+    '2025-04-04 02:00:00.000000+00',
+    '2025-04-04 02:00:00.000000+00'
+  );


### PR DESCRIPTION
Part of https://elhub.atlassian.net/browse/TDX-1576

For grants/consume, it is currently possible to get two requests simultaneously that both consume a grant and receive a 200. It was possible since the state validation was performed in the handler non-atomically with the update. It does not cause an inconsistent db state, but should still not be supported.

This PR makes the state validation atomic with the update, moving some responsibility from handler to repo.

The state validation pattern is in line with the patch applied [here](https://github.com/elhub/auth-grant-manager/commit/39991351a37e11c1ada9f7baa2ec613f5470be3e), but less consequential.