### PR TITLE
fix(trace): centralize trace header handling

### DIFF
--- a/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
+++ b/src/main/kotlin/no/elhub/auth/config/ErrorHandling.kt
@@ -21,7 +21,7 @@ fun Application.configureErrorHandling() {
             val (status, body) = buildApiErrorResponse(
                 status = HttpStatusCode.BadRequest,
                 title = "Invalid trace ID",
-                detail = "Header 'ElhubTraceID' must be a valid UUID"
+                detail = "Header 'ElhubTraceId' must be a valid UUID"
             )
             call.respond(status, body)
         }

--- a/src/main/kotlin/no/elhub/auth/config/Logging.kt
+++ b/src/main/kotlin/no/elhub/auth/config/Logging.kt
@@ -7,6 +7,7 @@ import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.calllogging.processingTimeMillis
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
+import no.elhub.auth.features.common.TRACE_ID_MDC_KEY
 import no.elhub.auth.features.openapi.API_PATH_OPENAPI
 import org.slf4j.event.Level
 
@@ -18,7 +19,7 @@ fun Application.configureLogging() {
     )
     install(CallLogging) {
         level = Level.INFO
-        callIdMdc("traceId")
+        callIdMdc(TRACE_ID_MDC_KEY)
         mdc("agent") { call ->
             call.request.headers["User-Agent"].orEmpty()
         }

--- a/src/main/kotlin/no/elhub/auth/config/Tracing.kt
+++ b/src/main/kotlin/no/elhub/auth/config/Tracing.kt
@@ -3,9 +3,9 @@ package no.elhub.auth.config
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.callid.CallId
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
 import java.util.UUID
 
-private const val ELHUB_TRACE_ID_HEADER = "ElhubTraceID"
 private const val ELHUB_TRACE_ID_HEADER_DEPRECATED = "Elhub-Trace-Id"
 
 fun Application.configureRequestTracing() {

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/structuredata/meteringpoints/MeteringPointsService.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/structuredata/meteringpoints/MeteringPointsService.kt
@@ -10,6 +10,8 @@ import io.ktor.http.isSuccess
 import no.elhub.auth.features.businessprocesses.common.JwtTokenProvider
 import no.elhub.auth.features.businessprocesses.structuredata.common.ClientError
 import no.elhub.auth.features.businessprocesses.structuredata.common.mapErrorsFromServer
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
+import no.elhub.auth.features.common.TraceIdContext
 import org.slf4j.LoggerFactory
 
 interface MeteringPointsService {
@@ -26,12 +28,18 @@ class MeteringPointsApi(
 ) : MeteringPointsService {
     private val logger = LoggerFactory.getLogger(MeteringPointsService::class.java)
 
-    override suspend fun getMeteringPointByIdAndElhubInternalId(meteringPointId: String, elhubInternalId: String): Either<ClientError, MeteringPointResponse> =
-        Either.catch {
+    override suspend fun getMeteringPointByIdAndElhubInternalId(meteringPointId: String, elhubInternalId: String): Either<ClientError, MeteringPointResponse> {
+        val traceId = TraceIdContext.currentOrNull()
+        if (traceId == null) {
+            logger.error("event=metering_point_lookup_missing_trace_id")
+        }
+
+        return Either.catch {
             val jwtToken = tokenProvider.getToken()
             val response = client.get("${meteringPointsApiConfig.serviceUrl}/metering-points/$meteringPointId?endUserId=$elhubInternalId") {
                 header("Authorization", "Bearer $jwtToken")
                 header("User-Agent", "auth-grant-manager")
+                traceId?.let { header(ELHUB_TRACE_ID_HEADER, it) }
             }
             if (response.status.isSuccess()) {
                 val responseBody: MeteringPointResponse = response.body()
@@ -44,6 +52,7 @@ class MeteringPointsApi(
             logger.error("Failed to fetch metering point: {}", throwable.message)
             ClientError.UnexpectedError(throwable)
         }
+    }
 }
 
 data class MeteringPointsApiConfig(

--- a/src/main/kotlin/no/elhub/auth/features/businessprocesses/structuredata/organisations/OrganisationsService.kt
+++ b/src/main/kotlin/no/elhub/auth/features/businessprocesses/structuredata/organisations/OrganisationsService.kt
@@ -5,9 +5,12 @@ import arrow.core.left
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.http.isSuccess
 import no.elhub.auth.features.businessprocesses.structuredata.common.ClientError
 import no.elhub.auth.features.businessprocesses.structuredata.common.mapErrorsFromServer
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
+import no.elhub.auth.features.common.TraceIdContext
 import org.slf4j.LoggerFactory
 
 interface OrganisationsService {
@@ -23,9 +26,16 @@ class OrganisationsApi(
 ) : OrganisationsService {
     private val logger = LoggerFactory.getLogger(OrganisationsService::class.java)
 
-    override suspend fun getPartyByIdAndPartyType(partyId: String, partyType: PartyType): Either<ClientError, PartyResponse> =
-        Either.catch {
-            val response = client.get("${organisationsApiConfig.serviceUrl}/parties/$partyId?partyType=$partyType")
+    override suspend fun getPartyByIdAndPartyType(partyId: String, partyType: PartyType): Either<ClientError, PartyResponse> {
+        val traceId = TraceIdContext.currentOrNull()
+        if (traceId == null) {
+            logger.error("event=organisation_lookup_missing_trace_id")
+        }
+
+        return Either.catch {
+            val response = client.get("${organisationsApiConfig.serviceUrl}/parties/$partyId?partyType=$partyType") {
+                traceId?.let { header(ELHUB_TRACE_ID_HEADER, it) }
+            }
             if (response.status.isSuccess()) {
                 val responseBody: PartyResponse = response.body()
                 responseBody
@@ -37,6 +47,7 @@ class OrganisationsApi(
             logger.error("Failed to fetch party: {}", throwable.message)
             ClientError.UnexpectedError(throwable)
         }
+    }
 }
 
 data class OrganisationsApiConfig(

--- a/src/main/kotlin/no/elhub/auth/features/common/TraceIdContext.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/TraceIdContext.kt
@@ -1,0 +1,10 @@
+package no.elhub.auth.features.common
+
+import org.slf4j.MDC
+
+const val ELHUB_TRACE_ID_HEADER = "ElhubTraceID"
+const val TRACE_ID_MDC_KEY = "traceId"
+
+object TraceIdContext {
+    fun currentOrNull(): String? = MDC.get(TRACE_ID_MDC_KEY)?.takeIf { it.isNotBlank() }
+}

--- a/src/main/kotlin/no/elhub/auth/features/common/TraceIdContext.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/TraceIdContext.kt
@@ -2,7 +2,7 @@ package no.elhub.auth.features.common
 
 import org.slf4j.MDC
 
-const val ELHUB_TRACE_ID_HEADER = "ElhubTraceID"
+const val ELHUB_TRACE_ID_HEADER = "ElhubTraceId"
 const val TRACE_ID_MDC_KEY = "traceId"
 
 object TraceIdContext {

--- a/src/main/kotlin/no/elhub/auth/features/common/person/PersonService.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/person/PersonService.kt
@@ -16,11 +16,12 @@ import io.ktor.http.contentType
 import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
 import no.elhub.auth.features.businessprocesses.common.JwtTokenProvider
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
+import no.elhub.auth.features.common.TraceIdContext
 import no.elhub.devxp.jsonapi.request.JsonApiRequestResourceObject
 import no.elhub.devxp.jsonapi.response.JsonApiErrorCollection
 import no.elhub.devxp.jsonapi.response.JsonApiErrorObject
 import org.slf4j.LoggerFactory
-import org.slf4j.MDC
 import java.util.UUID
 
 interface PersonService {
@@ -32,16 +33,10 @@ class ApiPersonService(
     private val client: HttpClient,
     private val tokenProvider: JwtTokenProvider,
 ) : PersonService {
-
     private val logger = LoggerFactory.getLogger(PersonService::class.java)
 
-    private companion object {
-        const val TRACE_HEADER = "ElhubTraceId"
-        const val CALL_ID_MDC_KEY = "traceId"
-    }
-
     override suspend fun findOrCreateByNin(nin: String): Either<ClientError, Person> {
-        val traceId = MDC.get(CALL_ID_MDC_KEY)
+        val traceId = TraceIdContext.currentOrNull()
         val traceHeader = traceIdIsValid(traceId).getOrElse {
             logger.error("The required request header to auth-persons is missing! ")
             return ClientError.MissingHeader.left()
@@ -50,7 +45,7 @@ class ApiPersonService(
         return Either.catch {
             val jwtToken = tokenProvider.getToken()
             val response = client.post("${cfg.baseUri}/market-parties/v0/persons") {
-                headers[TRACE_HEADER] = traceHeader.toString()
+                headers[ELHUB_TRACE_ID_HEADER] = traceHeader.toString()
                 header("Authorization", "Bearer $jwtToken")
                 contentType(ContentType.Application.Json)
                 setBody(

--- a/src/test/kotlin/no/elhub/auth/config/TracingTest.kt
+++ b/src/test/kotlin/no/elhub/auth/config/TracingTest.kt
@@ -22,7 +22,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientCon
 private const val ELHUB_TRACE_ID_HEADER_DEPRECATED = "Elhub-Trace-Id"
 
 class TracingTest : FunSpec({
-    test("uses ElhubTraceID header as call id when present") {
+    test("uses ElhubTraceId header as call id when present") {
         val traceId = "850cf459-d425-409a-a05d-7c6c9d1c0d64"
 
         testApplication {
@@ -45,7 +45,7 @@ class TracingTest : FunSpec({
         }
     }
 
-    test("generates call id when ElhubTraceID header is missing") {
+    test("generates call id when ElhubTraceId header is missing") {
         testApplication {
             application {
                 configureRequestTracing()
@@ -65,7 +65,7 @@ class TracingTest : FunSpec({
         }
     }
 
-    context("returns 400 when ElhubTraceID header is invalid") {
+    context("returns 400 when ElhubTraceId header is invalid") {
         listOf(
             "not-a-uuid",
             "",
@@ -91,11 +91,11 @@ class TracingTest : FunSpec({
                     }
 
                     val response = jsonClient.get("/call-id") {
-                        headers.append("ElhubTraceID", invalidValue)
+                        headers.append("ElhubTraceId", invalidValue)
                     }
 
                     response.status shouldBe HttpStatusCode.BadRequest
-                    response.headers["ElhubTraceID"].shouldBeNull()
+                    response.headers["ElhubTraceId"].shouldBeNull()
                     response.headers["Elhub-Trace-Id"].shouldBeNull()
                     val responseJson: JsonApiErrorCollection = response.body()
                     responseJson.errors.apply {
@@ -103,7 +103,7 @@ class TracingTest : FunSpec({
                         this[0].apply {
                             status shouldBe "400"
                             title shouldBe "Invalid trace ID"
-                            detail shouldBe "Header 'ElhubTraceID' must be a valid UUID"
+                            detail shouldBe "Header 'ElhubTraceId' must be a valid UUID"
                         }
                     }
                 }

--- a/src/test/kotlin/no/elhub/auth/config/TracingTest.kt
+++ b/src/test/kotlin/no/elhub/auth/config/TracingTest.kt
@@ -14,9 +14,12 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
 import no.elhub.devxp.jsonapi.response.JsonApiErrorCollection
 import java.util.UUID
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+
+private const val ELHUB_TRACE_ID_HEADER_DEPRECATED = "Elhub-Trace-Id"
 
 class TracingTest : FunSpec({
     test("uses ElhubTraceID header as call id when present") {
@@ -33,12 +36,12 @@ class TracingTest : FunSpec({
             }
 
             val response = client.get("/call-id") {
-                headers.append("ElhubTraceID", traceId)
+                headers.append(ELHUB_TRACE_ID_HEADER, traceId)
             }
 
             response.bodyAsText() shouldBe traceId
-            response.headers["ElhubTraceID"] shouldBe traceId
-            response.headers["Elhub-Trace-Id"] shouldBe traceId
+            response.headers[ELHUB_TRACE_ID_HEADER] shouldBe traceId
+            response.headers[ELHUB_TRACE_ID_HEADER_DEPRECATED] shouldBe traceId
         }
     }
 
@@ -57,8 +60,8 @@ class TracingTest : FunSpec({
             val generatedTraceId = response.bodyAsText()
 
             UUID.fromString(generatedTraceId).toString() shouldBe generatedTraceId
-            response.headers["ElhubTraceID"] shouldBe generatedTraceId
-            response.headers["Elhub-Trace-Id"] shouldBe generatedTraceId
+            response.headers[ELHUB_TRACE_ID_HEADER] shouldBe generatedTraceId
+            response.headers[ELHUB_TRACE_ID_HEADER_DEPRECATED] shouldBe generatedTraceId
         }
     }
 

--- a/src/test/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/ChangeOfBalanceSupplierBusinessHandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/businessprocesses/changeofbalancesupplier/ChangeOfBalanceSupplierBusinessHandlerTest.kt
@@ -43,6 +43,7 @@ import no.elhub.auth.features.businessprocesses.structuredata.organisations.Orga
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.OrganisationsServiceTestData.NOT_BALANCE_SUPPLIER_PARTY_ID
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.OrganisationsServiceTestData.VALID_PARTY_ID
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.organisationsServiceHttpClient
+import no.elhub.auth.features.common.TRACE_ID_MDC_KEY
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyType.Organization
 import no.elhub.auth.features.common.party.PartyType.Person
@@ -57,6 +58,8 @@ import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
 import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 import no.elhub.auth.features.requests.create.command.TEXT_VERSION_KEY
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObject
+import org.slf4j.MDC
+import java.util.UUID
 
 private val VALID_PARTY = AuthorizationParty(id = VALID_PARTY_ID, type = Organization)
 private val AUTHORIZED_PARTY = VALID_PARTY
@@ -111,6 +114,7 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
         }
 
         beforeTest {
+            MDC.put(TRACE_ID_MDC_KEY, UUID.randomUUID().toString())
             clearMocks(edielService, answers = false, recordedCalls = true)
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(
                 EdielPartyRedirectResponseDto(
@@ -119,6 +123,10 @@ class ChangeOfBalanceSupplierBusinessHandlerTest :
                     )
                 )
             )
+        }
+
+        afterTest {
+            MDC.remove(TRACE_ID_MDC_KEY)
         }
 
         test("request validation fails on missing requestedFromName") {

--- a/src/test/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/MoveInAndChangeOfBalanceSupplierBusinessHandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/businessprocesses/moveinandchangeofbalancesupplier/MoveInAndChangeOfBalanceSupplierBusinessHandlerTest.kt
@@ -43,6 +43,7 @@ import no.elhub.auth.features.businessprocesses.structuredata.organisations.Orga
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.OrganisationsServiceTestData.NOT_BALANCE_SUPPLIER_PARTY_ID
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.OrganisationsServiceTestData.VALID_PARTY_ID
 import no.elhub.auth.features.businessprocesses.structuredata.organisations.organisationsServiceHttpClient
+import no.elhub.auth.features.common.TRACE_ID_MDC_KEY
 import no.elhub.auth.features.common.party.AuthorizationParty
 import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay
@@ -57,6 +58,7 @@ import no.elhub.auth.features.requests.common.CreateRequestBusinessMeta
 import no.elhub.auth.features.requests.common.CreateRequestBusinessModel
 import no.elhub.auth.features.requests.create.command.TEXT_VERSION_KEY
 import no.elhub.devxp.jsonapi.response.JsonApiResponseResourceObject
+import org.slf4j.MDC
 import java.util.UUID
 
 private val VALID_PARTY = AuthorizationParty(id = VALID_PARTY_ID, type = PartyType.Organization)
@@ -109,6 +111,7 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
         }
 
         beforeTest {
+            MDC.put(TRACE_ID_MDC_KEY, UUID.randomUUID().toString())
             clearMocks(edielService, answers = false, recordedCalls = true)
             coEvery { edielService.getPartyRedirect(any()) } returns Either.Right(
                 EdielPartyRedirectResponseDto(
@@ -117,6 +120,10 @@ class MoveInAndChangeOfBalanceSupplierBusinessHandlerTest :
                     )
                 )
             )
+        }
+
+        afterTest {
+            MDC.remove(TRACE_ID_MDC_KEY)
         }
 
         test("request validation allows missing moveInDate") {

--- a/src/test/kotlin/no/elhub/auth/features/businessprocesses/structuredata/meteringpoints/MeteringPointsApiTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/businessprocesses/structuredata/meteringpoints/MeteringPointsApiTest.kt
@@ -20,12 +20,18 @@ import io.mockk.mockk
 import kotlinx.serialization.json.Json
 import no.elhub.auth.features.businessprocesses.common.JwtTokenProvider
 import no.elhub.auth.features.businessprocesses.structuredata.common.ClientError
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
+import no.elhub.auth.features.common.TRACE_ID_MDC_KEY
+import org.slf4j.MDC
+import java.util.UUID
 
 class MeteringPointsApiTest : FunSpec({
 
     val validMeteringPointId = "300362000000000008"
     val endUserId = "d6784082-8344-e733-e053-02058d0a6752"
     val otherEndUserId = "00662e04-2fd6-3b06-b672-3965abe7b7c5"
+    lateinit var traceId: String
+    var capturedTraceId: String? = null
     val serviceUrl = "http://localhost:8080"
     val config = MeteringPointsApiConfig(
         serviceUrl = serviceUrl,
@@ -46,6 +52,7 @@ class MeteringPointsApiTest : FunSpec({
 
         engine {
             addHandler { request ->
+                capturedTraceId = request.headers[ELHUB_TRACE_ID_HEADER]
                 when (request.url.fullPath) {
                     "/metering-points/$validMeteringPointId?endUserId=$endUserId" -> {
                         respond(
@@ -80,6 +87,31 @@ class MeteringPointsApiTest : FunSpec({
         }
     }
     val service = MeteringPointsApi(config, client, mockJwtTokenProvider)
+
+    beforeTest {
+        traceId = UUID.randomUUID().toString()
+        capturedTraceId = null
+        MDC.put(TRACE_ID_MDC_KEY, traceId)
+    }
+
+    afterTest {
+        MDC.remove(TRACE_ID_MDC_KEY)
+    }
+
+    test("Includes trace id header from MDC in outgoing request") {
+        service.getMeteringPointByIdAndElhubInternalId(validMeteringPointId, endUserId).shouldBeRight()
+
+        capturedTraceId shouldBe traceId
+    }
+
+    test("Missing trace id in MDC does not fail request") {
+        MDC.remove(TRACE_ID_MDC_KEY)
+
+        val response = service.getMeteringPointByIdAndElhubInternalId(validMeteringPointId, endUserId)
+
+        response.shouldBeRight()
+        capturedTraceId.shouldBeNull()
+    }
 
     test("Valid metering point id and end user id") {
         val response = service.getMeteringPointByIdAndElhubInternalId(validMeteringPointId, endUserId)

--- a/src/test/kotlin/no/elhub/auth/features/businessprocesses/structuredata/organisations/OrganisationsApiTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/businessprocesses/structuredata/organisations/OrganisationsApiTest.kt
@@ -3,6 +3,7 @@ package no.elhub.auth.features.businessprocesses.structuredata.organisations
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -15,11 +16,17 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import no.elhub.auth.features.businessprocesses.structuredata.common.ClientError
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
+import no.elhub.auth.features.common.TRACE_ID_MDC_KEY
+import org.slf4j.MDC
+import java.util.UUID
 
 class OrganisationsApiTest : FunSpec({
     val validPartyId = "3004300000019"
     val notBalanceSupplierPartyId = "3004300000099"
     val notValidPartyId = "123"
+    val traceId = UUID.randomUUID().toString()
+    var capturedTraceIdHeader: String? = null
     val serviceUrl = "http://localhost:8080/v1/service"
     val config = OrganisationsApiConfig(
         serviceUrl = serviceUrl,
@@ -42,6 +49,7 @@ class OrganisationsApiTest : FunSpec({
 
         engine {
             addHandler { request ->
+                capturedTraceIdHeader = request.headers[ELHUB_TRACE_ID_HEADER]
                 when (request.url.fullPath) {
                     "/v1/service/parties/$validPartyId?partyType=BalanceSupplier" -> {
                         respond(
@@ -95,6 +103,30 @@ class OrganisationsApiTest : FunSpec({
         }
     }
     val service = OrganisationsApi(config, client)
+
+    beforeTest {
+        capturedTraceIdHeader = null
+        MDC.put(TRACE_ID_MDC_KEY, traceId)
+    }
+
+    afterTest {
+        MDC.remove(TRACE_ID_MDC_KEY)
+    }
+
+    test("sends trace header from shared trace context") {
+        service.getPartyByIdAndPartyType(validPartyId, PartyType.BalanceSupplier).shouldBeRight()
+
+        capturedTraceIdHeader shouldBe traceId
+    }
+
+    test("missing trace id does not fail request") {
+        MDC.remove(TRACE_ID_MDC_KEY)
+
+        val response = service.getPartyByIdAndPartyType(validPartyId, PartyType.BalanceSupplier)
+
+        response.shouldBeRight()
+        capturedTraceIdHeader.shouldBeNull()
+    }
 
     test("Valid partyId and corresponding partyType") {
         val response = service.getPartyByIdAndPartyType(validPartyId, PartyType.BalanceSupplier)

--- a/src/test/kotlin/no/elhub/auth/features/common/person/ApiPersonServiceTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/common/person/ApiPersonServiceTest.kt
@@ -1,0 +1,95 @@
+package no.elhub.auth.features.common.person
+
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.serialization.json.Json
+import no.elhub.auth.features.businessprocesses.common.JwtTokenProvider
+import no.elhub.auth.features.common.ELHUB_TRACE_ID_HEADER
+import no.elhub.auth.features.common.TRACE_ID_MDC_KEY
+import org.slf4j.MDC
+import java.util.UUID
+
+class ApiPersonServiceTest : FunSpec({
+    val nin = "12345678910"
+    val traceId = UUID.randomUUID().toString()
+    var capturedTraceIdHeader: String? = null
+    val tokenProvider = mockk<JwtTokenProvider>()
+    coEvery { tokenProvider.getToken() } returns "token"
+
+    val client = HttpClient(MockEngine) {
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                }
+            )
+        }
+
+        engine {
+            addHandler { request ->
+                capturedTraceIdHeader = request.headers[ELHUB_TRACE_ID_HEADER]
+                when (request.url.fullPath) {
+                    "/market-parties/v0/persons" -> respond(
+                        content = """
+                            {
+                              "data": {
+                                "type": "Person",
+                                "id": "11111111-1111-1111-1111-111111111111",
+                                "attributes": {
+                                  "type": "Person",
+                                  "id": "11111111-1111-1111-1111-111111111111"
+                                }
+                              }
+                            }
+                        """.trimIndent(),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                    )
+
+                    else -> respond("{}", HttpStatusCode.NotFound)
+                }
+            }
+        }
+    }
+
+    val service = ApiPersonService(
+        cfg = PersonApiConfig(baseUri = "http://localhost"),
+        client = client,
+        tokenProvider = tokenProvider
+    )
+
+    beforeTest {
+        capturedTraceIdHeader = null
+        MDC.put(TRACE_ID_MDC_KEY, traceId)
+    }
+
+    afterTest {
+        MDC.remove(TRACE_ID_MDC_KEY)
+    }
+
+    test("sends auth persons trace header from shared trace context") {
+        service.findOrCreateByNin(nin).shouldBeRight()
+
+        capturedTraceIdHeader shouldBe traceId
+    }
+
+    test("returns missing header when trace id is absent") {
+        MDC.remove(TRACE_ID_MDC_KEY)
+
+        service.findOrCreateByNin(nin).shouldBeLeft(ClientError.MissingHeader)
+    }
+})


### PR DESCRIPTION
Make sure we pass `traceId` to every service