### PR TITLE
feat(documents/confirm): Constrain PDF upload size to 1 MB [minor]

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <devxp-build-configuration.version>1.76.5</devxp-build-configuration.version>
+        <devxp-build-configuration.version>1.76.6</devxp-build-configuration.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
+++ b/src/main/kotlin/no/elhub/auth/features/common/Errors.kt
@@ -14,6 +14,7 @@ sealed class InputError : Error {
     data object IdMismatchError : InputError()
     data class MissingFieldError(val fields: List<String>) : InputError()
     data class InvalidFieldValueError(val detail: String) : InputError()
+    data class ContentTooLargeError(val detail: String) : InputError()
 }
 
 sealed class CommandError : Error {
@@ -137,6 +138,12 @@ fun InputError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollection
         is InputError.InvalidFieldValueError -> buildApiErrorResponse(
             status = HttpStatusCode.BadRequest,
             title = "Invalid field value in request body",
+            detail = this.detail
+        )
+
+        is InputError.ContentTooLargeError -> buildApiErrorResponse(
+            status = HttpStatusCode.PayloadTooLarge,
+            title = "Content too large",
             detail = this.detail
         )
     }

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Route.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Route.kt
@@ -18,6 +18,7 @@ import no.elhub.auth.features.common.validatePathId
 import org.slf4j.LoggerFactory
 
 const val DOCUMENT_ID_PARAM = "id"
+const val PDF_MAX_BYTES = 1L * 1024L * 1024L // 1 MB
 private val logger = LoggerFactory.getLogger(Route::class.java)
 
 fun Route.route(handler: Handler) {
@@ -35,7 +36,15 @@ fun Route.route(handler: Handler) {
                 return@put
             }
 
-        val signedDocument = call.receiveChannel().readRemaining().readByteArray()
+        // Read 1 extra byte, then check how much was read
+        val signedDocument = call.receiveChannel().readRemaining(max = PDF_MAX_BYTES + 1).readByteArray()
+        if (signedDocument.size > PDF_MAX_BYTES) {
+            val (status, body) = InputError.ContentTooLargeError(detail = "Signed PDF upload size is limited to 1 MB")
+                .toApiErrorResponse()
+            call.respond(status, body)
+            return@put
+        }
+
         if (signedDocument.isEmpty()) {
             val (status, body) = InputError.MissingInputError.toApiErrorResponse()
             call.respond(status, body)

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -229,6 +229,8 @@ paths:
           $ref: '#/components/responses/404NotFoundError'
         '406':
           $ref: '#/components/responses/406NotAcceptableError'
+        '413':
+          $ref: '#/components/responses/413ContentTooLargeError'
         '415':
           $ref: '#/components/responses/415UnsupportedMediaTypeError'
         '422':
@@ -751,6 +753,23 @@ components:
                   - status: '406'
                     title: 'Not Acceptable'
                     detail: 'The requested media type is not supported.'
+                    meta:
+                      createdAt: '2025-12-17T12:51:57+01:00'
+    413ContentTooLargeError:
+      description: >
+        Content Too Large. The request body exceeds the maximum allowed size.
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: './schemas/json-api-error.schema.json'
+          examples:
+            contentTooLarge:
+              summary: Content too large error example
+              value:
+                errors:
+                  - status: '413'
+                    title: 'Content Too Large'
+                    detail: 'Signed PDF upload size is limited to 1 MB.'
                     meta:
                       createdAt: '2025-12-17T12:51:57+01:00'
     409ConflictError:

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/RouteTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/RouteTest.kt
@@ -45,11 +45,11 @@ class RouteTest : FunSpec({
         }
     }
 
-    test("PUT /{id}.pdf returns 204 when authorized as org and handler succeeds") {
+    test("PUT /{id}.pdf returns 204 when authorized as org, handler succeeds, and PDF size is at limit") {
         coEvery { handler.invoke(any()) } returns Unit.right()
         testApplication {
             setupAppWith(authorizedOrg) { route(handler) }
-            val response = client.putPdf("/02fe286b-4519-4ba8-9c84-dc18bffc9eb3.pdf", Random.nextBytes(256))
+            val response = client.putPdf("/02fe286b-4519-4ba8-9c84-dc18bffc9eb3.pdf", Random.nextBytes(1 * 1024 * 1024))
             response.status shouldBe HttpStatusCode.NoContent
             response.bodyAsText().shouldBeEmpty()
             coVerify(exactly = 1) { handler.invoke(any()) }
@@ -104,6 +104,24 @@ class RouteTest : FunSpec({
                 this[0].apply {
                     title shouldBe "Missing input"
                     detail shouldBe "Necessary information was not provided"
+                }
+            }
+            coVerify(exactly = 0) { handler.invoke(any()) }
+        }
+    }
+
+    test("PUT /{id}.pdf returns 413 when document too big") {
+        testApplication {
+            setupAppWith(authorizedOrg) { route(handler) }
+            val response =
+                client.putPdf("/4803264d-11a4-4d6a-81f4-996986cb7b35.pdf", Random.nextBytes(1 * 1024 * 1024 + 1))
+            response.status shouldBe HttpStatusCode.PayloadTooLarge
+            val responseJson: JsonApiErrorCollection = response.body()
+            responseJson.errors.apply {
+                size shouldBe 1
+                this[0].apply {
+                    title shouldBe "Content too large"
+                    detail shouldBe "Signed PDF upload size is limited to 1 MB"
                 }
             }
             coVerify(exactly = 0) { handler.invoke(any()) }


### PR DESCRIPTION
https://elhub.atlassian.net/browse/TDX-1577

On "Payload" vs. "Content": The HTTP error is called PayloadTooLarge in the code, but this is outdated after [RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#name-413-content-too-large) (with this [reasoning](https://datatracker.ietf.org/doc/html/rfc9110#name-changes-from-rfc-7231)).