### PR TITLE
fix(ci): remove separate gitops job for integration test

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -36,7 +36,9 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
                     changelogDirectory = dbDirectory
                     liquibaseEntrypoint = liquiEntryPoint
                 }
+            }
 
+            parallel {
                 dockerBuild {
                     source = Source.CommitSha
                     dockerfileName = "integration-test/Dockerfile"
@@ -47,9 +49,7 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
                     }
                     tags = setOf("latest")
                 }
-            }
 
-            parallel {
                 gitOps {
                     clusters = setOf(
                         KubeCluster.TEST9,
@@ -62,14 +62,6 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
                     autoMerge = true
                     enableChangelog = true
                 }.triggerOnVcsChange()
-
-                gitOps {
-                    clusters = setOf(KubeCluster.TEST9)
-                    projectName = "auth-grant-manager-integration-test"
-                    tagKey = "agmVersion"
-                    gitOpsRepository = gitOpsRepo
-                    autoMerge = true
-                }
 
                 gitOps {
                     clusters = setOf(KubeCluster.MARKET_TRIAL_1)


### PR DESCRIPTION
The integration test job will be set up as part of the AGM argo app, see [this](https://github.com/elhub/auth/pull/2430), therefore we no longer need a separate gitOps entry for it here.