### PR TITLE
fix(integration test): chown /app to non-privileged user

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -36,9 +36,7 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
                     changelogDirectory = dbDirectory
                     liquibaseEntrypoint = liquiEntryPoint
                 }
-            }
 
-            parallel {
                 dockerBuild {
                     source = Source.CommitSha
                     dockerfileName = "integration-test/Dockerfile"
@@ -49,8 +47,9 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
                     }
                     tags = setOf("latest")
                 }
+            }
 
-                gitOps {
+            parallel {
                     clusters = setOf(
                         KubeCluster.TEST9,
                         KubeCluster.TEST8,

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -50,6 +50,7 @@ elhubProject(group = Group.AUTH, name = "auth-grant-manager") {
             }
 
             parallel {
+                gitOps {
                     clusters = setOf(
                         KubeCluster.TEST9,
                         KubeCluster.TEST8,

--- a/integration-test/Dockerfile
+++ b/integration-test/Dockerfile
@@ -11,6 +11,9 @@ COPY integration-test/package.json integration-test/package-lock.json integratio
 RUN cd integration-test && npm ci
 
 COPY integration-test/authorization-document-flow.sh integration-test/bankid-sign.ts integration-test/
-RUN chmod +x integration-test/authorization-document-flow.sh
+RUN chmod +x integration-test/authorization-document-flow.sh \
+  && chown -R 65532:65532 /app
+
+USER 65532
 
 CMD ["bash", "integration-test/authorization-document-flow.sh"]


### PR DESCRIPTION
- fix 1:
In Kubernetes, the container is running as 65532, see [this](https://github.com/elhub/auth/blob/601699a0e767ed28d0205dd177de70875297d06f/apps/base/auth-grant-manager/templates/integration-test-job.yaml#L19)
This user (unprivileged) needs to own `/app` in the Docker container in order to write files.

- fix 2:
Ensure gitOps runs *after* docker build has finished.