### PR TITLE
feat(ci): bump build config to enable cyclonedx sbom upload

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <devxp-build-configuration.version>1.77.16</devxp-build-configuration.version>
+        <devxp-build-configuration.version>1.78.0</devxp-build-configuration.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Relates to [TDX-1680](https://elhub.atlassian.net/browse/TDX-1680), just getting the feature out to a few projects.

Enables [this feature](https://github.com/elhub/devxp-build-configuration/pull/752) in this project.

[TDX-1680]: https://elhub.atlassian.net/browse/TDX-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ