### PR TITLE
fix(documents): log invalid confirm status

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -45,8 +45,13 @@ class Handler(
             ConfirmError.InvalidRequestedByError
         }
 
-        ensure(document.status == AuthorizationDocument.Status.Pending) {
-            ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm.")
+        if (document.status != AuthorizationDocument.Status.Pending) {
+            log.info(
+                "event=authorization_document_confirm_invalid_status documentId={} status={}",
+                document.id,
+                document.status,
+            )
+            raise(ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm."))
         }
 
         ensure(document.validTo >= currentTimeUtc()) {

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -51,7 +51,11 @@ class Handler(
                 document.id,
                 document.status,
             )
-            raise(ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm."))
+            raise(
+                ConfirmError.IllegalStateError(
+                    "AuthorizationDocument cannot be confirmed from status '${document.status.name}'. Only 'Pending' documents can be confirmed."
+                )
+            )
         }
 
         ensure(document.validTo >= currentTimeUtc()) {

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/ConfirmErrorJsonApiResponseTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/ConfirmErrorJsonApiResponseTest.kt
@@ -37,10 +37,12 @@ class ConfirmErrorJsonApiResponseTest : FunSpec({
             title = "Party not authorized",
             detail = "RequestedBy must match the authorized party."
         ),
-        ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm.") to Expectation(
+        ConfirmError.IllegalStateError(
+            "AuthorizationDocument cannot be confirmed from status 'Signed'. Only 'Pending' documents can be confirmed."
+        ) to Expectation(
             status = HttpStatusCode.UnprocessableEntity,
             title = "Invalid status state",
-            detail = "AuthorizationDocument must be in 'Pending' status to confirm."
+            detail = "AuthorizationDocument cannot be confirmed from status 'Signed'. Only 'Pending' documents can be confirmed."
         ),
         ConfirmError.ExpiredError to Expectation(
             status = HttpStatusCode.UnprocessableEntity,

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
@@ -193,7 +193,11 @@ class HandlerTest : FunSpec({
             )
         )
 
-        result.shouldBeLeft(ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm."))
+        result.shouldBeLeft(
+            ConfirmError.IllegalStateError(
+                "AuthorizationDocument cannot be confirmed from status 'Signed'. Only 'Pending' documents can be confirmed."
+            )
+        )
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }
@@ -222,7 +226,11 @@ class HandlerTest : FunSpec({
             )
         )
 
-        result.shouldBeLeft(ConfirmError.IllegalStateError("AuthorizationDocument must be in 'Pending' status to confirm."))
+        result.shouldBeLeft(
+            ConfirmError.IllegalStateError(
+                "AuthorizationDocument cannot be confirmed from status 'Signed'. Only 'Pending' documents can be confirmed."
+            )
+        )
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }


### PR DESCRIPTION
Log the current document status before rejecting confirm requests for non-pending documents.
This keeps the existing 422 behavior unchanged while making it easier to diagnose why confirmation was refused.
Resolves TDX-1701
