### PR TITLE
fix(renovate): renovate setting for playwright in dockerfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,27 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>elhub/devxp-renovate"]
+  "extends": ["github>elhub/devxp-renovate"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^integration-test/Dockerfile$"],
+      "matchStrings": [
+        "FROM mcr\\.microsoft\\.com/playwright:v(?<currentValue>\\d+\\.\\d+\\.\\d+)(?:-[a-z]+)?\\b"
+      ],
+      "depNameTemplate": "playwright",
+      "datasourceTemplate": "npm"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["playwright"],
+      "groupName": "playwright (npm + docker image)"
+    },
+    {
+      "description": "Disable the built-in dockerfile manager for the playwright base image; the custom regex manager above tracks it against the npm datasource instead so it stays grouped with package.json",
+      "matchManagers": ["dockerfile"],
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
this should keep the playwright docker image (containing rendering engine etc. for playwright) in `./integration-test/Dockerfile` in lockstep with the library in `./integration-test/package.json` in upcoming renovate PRs

renovate would otherwise bump the one in package by itself, leaving them misaligned and failing :(