### PR TITLE
chore(deps): playwright to resolute (u26)

### DIFF
--- a/integration-test/Dockerfile
+++ b/integration-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.61.0-jammy
+FROM mcr.microsoft.com/playwright:v1.62.1-resolute
 
 RUN apt-get update && apt-get install -y curl jq ca-certificates && rm -rf /var/lib/apt/lists/* \
   && curl -fsSL https://vault.elhub.cloud/v1/pki_root/ca/pem \


### PR DESCRIPTION
bumping the major ubuntu version for the playwright docker image to 26, resolute. then it should update nicely with renovate after [this pr is merged](https://github.com/elhub/auth-grant-manager/pull/707)