### PR TITLE
fix(documents): remove dead ensure-block in documents confirm handler

### DIFF
--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/ConfirmError.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/ConfirmError.kt
@@ -20,7 +20,6 @@ sealed class ConfirmError {
     data object RequestedByResolutionError : ConfirmError()
     data object InvalidRequestedByError : ConfirmError()
     data class IllegalStateError(val detail: String) : ConfirmError()
-    data object ExpiredError : ConfirmError()
 }
 
 private const val END_USER_SIGNATURE_VALIDATION_FAILED = "End user signature validation failed"
@@ -54,12 +53,6 @@ fun ConfirmError.toApiErrorResponse(): Pair<HttpStatusCode, JsonApiErrorCollecti
             status = HttpStatusCode.UnprocessableEntity,
             title = "Invalid status state",
             detail = this.detail
-        )
-
-        ConfirmError.ExpiredError -> buildApiErrorResponse(
-            status = HttpStatusCode.UnprocessableEntity,
-            title = "AuthorizationDocument has expired",
-            detail = "Validity period has passed."
         )
 
         ConfirmError.SignatoryResolutionError,

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -4,7 +4,6 @@ import arrow.core.Either
 import arrow.core.raise.either
 import arrow.core.raise.ensure
 import no.elhub.auth.features.common.RepositoryReadError
-import no.elhub.auth.features.common.currentTimeUtc
 import no.elhub.auth.features.common.party.PartyService
 import no.elhub.auth.features.common.party.PartyType
 import no.elhub.auth.features.common.toTimeZoneOffsetDateTimeAtStartOfDay

--- a/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
+++ b/src/main/kotlin/no/elhub/auth/features/documents/confirm/Handler.kt
@@ -58,10 +58,6 @@ class Handler(
             )
         }
 
-        ensure(document.validTo >= currentTimeUtc()) {
-            ConfirmError.ExpiredError
-        }
-
         val signatoryIdentifier =
             signatureService.validateSignaturesAndReturnSignatory(command.signedFile, document.file)
                 .mapLeft {

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/ConfirmErrorJsonApiResponseTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/ConfirmErrorJsonApiResponseTest.kt
@@ -43,11 +43,6 @@ class ConfirmErrorJsonApiResponseTest : FunSpec({
             status = HttpStatusCode.UnprocessableEntity,
             title = "Invalid status state",
             detail = "AuthorizationDocument cannot be confirmed from status 'Signed'. Only 'Pending' documents can be confirmed."
-        ),
-        ConfirmError.ExpiredError to Expectation(
-            status = HttpStatusCode.UnprocessableEntity,
-            title = "AuthorizationDocument has expired",
-            detail = "Validity period has passed."
         )
     ).forEach { (error, expected) ->
         test("maps ${error::class.simpleName} to ${expected.status}") {

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
@@ -237,12 +237,12 @@ class HandlerTest : FunSpec({
         coVerify(exactly = 0) { documentRepository.confirmWithGrant(any(), any(), any(), any(), any()) }
     }
 
-    test("returns ExpiredError when document validity period has passed") {
+    test("returns ExpiredError when document is expired") {
         val documentId = UUID.randomUUID()
 
         val document = createDocument(
             documentId = documentId,
-            validTo = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(10)
+            status = AuthorizationDocument.Status.Expired,
         )
 
         val documentRepository = mockk<DocumentRepository>()
@@ -259,7 +259,11 @@ class HandlerTest : FunSpec({
             )
         )
 
-        result.shouldBeLeft(ConfirmError.ExpiredError)
+        result.shouldBeLeft(
+            ConfirmError.IllegalStateError(
+                "AuthorizationDocument cannot be confirmed from status 'Expired'. Only 'Pending' documents can be confirmed."
+            )
+        )
         coVerify(exactly = 1) { documentRepository.find(documentId) }
         verify(exactly = 0) { signatureService.validateSignaturesAndReturnSignatory(any(), any()) }
         coVerify(exactly = 0) { documentRepository.findScopeIds(any()) }

--- a/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
+++ b/src/test/kotlin/no/elhub/auth/features/documents/confirm/HandlerTest.kt
@@ -31,7 +31,6 @@ import no.elhub.auth.features.documents.common.SignatureValidationError
 import no.elhub.auth.features.grants.AuthorizationGrant
 import no.elhub.auth.features.grants.common.CreateGrantProperties
 import java.time.OffsetDateTime
-import java.time.ZoneOffset
 import java.util.UUID
 
 class HandlerTest : FunSpec({


### PR DESCRIPTION
https://elhub.atlassian.net/browse/TDX-1200

status mapping is already done on the repository level, mapping to expired. the block removed here is unreachable outside of unit tests.